### PR TITLE
Rewrite to match suggestions from issues and feedback.

### DIFF
--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -52,10 +52,9 @@ import and export sections of the module. All imported/exported exceptions must
 be named to reconcile exception tags between modules.
 
 Exception tags are used by throw and catch instructions. The throw instruction
-uses the tag to call the appropriate exception constructor, which gets values
-defined by the corresponding type signature of the exception. The catch
-instruction uses the tag to identify if the thrown exception is one it can
-catch.
+uses the tag to allocate the exception with the corresponding data fields
+defined by the exception's type signature. The catch instruction uses the tag to
+identify if the thrown exception is one it can catch.
 
 Exceptions can also be thrown by called, imported functions. If it corresponds
 to an imported exception, it can be caught by an appropriate catch instruction.
@@ -118,15 +117,15 @@ In the initial implementation, try blocks may only yield 0 or 1 values.
 ### Throws
 
 The _throw_ instruction has a single immediate argument, an exception tag.  The
-exception tag is used to define the constructed exception. The arguments for the
-constructor must be on top of the value stack, and must correspond to the
-exception type signature for the exception.
+exception tag is used to define the data fields of the allocated exception. The
+values for the data fields must be on top of the value stack, and must
+correspond to the exception type signature for the exception.
 
-When an exception is thrown, the values on the stack (corresponding to the type
-signature) are popped off and the corresponding exception is constructed.  The
-exception is stored internally for access when the exception is caught. The
-runtime then searches for nearest enclosing try block body that execution is
-in. That try block is called the _catching_ try block.
+When an exception is thrown, the exception is allocated and the values on the
+stack (corresponding to the type signature) are popped off and assigned to the
+allocated exception.  The exception is stored internally for access when the
+exception is caught. The runtime then searches for nearest enclosing try block
+body that execution is in. That try block is called the _catching_ try block.
 
 If the throw appears within the body of a try block, it is the catching try
 block.
@@ -144,13 +143,11 @@ are not in the body of the try block.
 Once a catching try block is found for the throw, the value stack is popped back
 to the size the value stack had when the try block was entered. Then, tagged
 catch blocks are tried in the order they appear in the catching try block, until
-one matches. A tagged catch block matches if the corresponding `catch`
-instruction is applicable, i.e. the corresponding exception was generated using
-the constructor defined by the tag of the `catch` instruction.
+one matches.
 
 If a matched tagged catch block is found, control is transferred to the body of
-the catch block, and the constructor arguments (when the exception was created)
-are pushed back onto the stack.
+the catch block, and the data fields of the exception are pushed back onto the
+stack.
 
 Otherwise, control is transferred to the body of the default catch
 block. However, unlike tagged catch blocks, the constructor arguments are not

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -84,7 +84,7 @@ else
 end
 ```
 
-A try block also contain one or more catch blocks, and all but the last catch
+A try block also contains one or more catch blocks, and all but the last catch
 block must begin with a`catch` instruction. The last catch block can begin with
 either a `catch` or `else` instruction. The `catch`/`else` instructions (within
 the try construct) are called the _catching_ instructions.
@@ -228,8 +228,8 @@ declares exception types using exception type signatures.
 
 The _exception index space_ indexes all imported and internally-defined
 exceptions, assigning monotonically-increasing indices based on the order
-defined in the exception section. Thus, the index space starts at zero with
-imported exceptions followed by internally-defined exceptions.
+defined in the import and exception sections. Thus, the index space starts at
+zero with imported exceptions followed by internally-defined exceptions.
 
 **Note:** The exception index space is a change to the
 [Modules document](https://github.com/WebAssembly/design/blob/master/Modules.md),

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -191,13 +191,15 @@ This section describes changes in
 the
 [binary encoding design document](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md).
 
-### Exception type signatures
+### except_type
 
 An exception is described by its exception type signature, which corresponds to
-the function signature of the exception constructor. Hence, an exception _type
-signature_ is a `func_type` that returns zero values.
+the data fields of the exception.
 
-Exception type signatures must appear in the type section.
+| Field | Type | Description |
+|-------|------|-------------|
+| `count` | `varuint32` | The number of known exceptions |
+| `sig` | `value_type*` | The type signature of each exception |
 
 ### External kind
 
@@ -219,8 +221,8 @@ declares exception types using exception type signatures.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| count | `varuint32` | count of the number of exception types to follow |
-| entries | `func_type` | sequence of indices into the type section |
+| count | `varuint32` | count of the number of exceptions to follow |
+| sig | `except_type*` | The type signature of the data fields for the exception |
 
 ### Import section
 
@@ -231,7 +233,7 @@ If the `kind` is `Exception`:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| tag   | varuint32 | index into exception section |
+| tag   | varuint32 | index into the exception section |
 | type  | `varuint32` | type index of the function signature |
 
 ### Export section
@@ -252,7 +254,7 @@ follows:
 | --------- | ---- | ----------- |
 | [Function](#function-names) | `1` | Assigns names to functions |
 | [Local](#local-names) | `2` | Assigns names to locals in functions |
-| [Exception](#(exception-names) | `3` | Assigns names to exception types |
+| [Exception](#exception-names) | `3` | Assigns names to exception types |
 
 ### Exception names
 


### PR DESCRIPTION
Cleans up the syntax of try blocks. Catch blocks are now part of try blocks and not nested.

Uses type section to define signatures of exceptions, with the view that the type signature is defining the constructor.

The exception section is defining exceptions (not constructors). Each entry defines the type signature of the   corresponding exception constructor.
