### PR TITLE
Handle issues 7, 9, and 10.

### DIFF
--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -364,7 +364,7 @@ throws, and rethrows as follows:
 | `try` | `0x06` | sig : `block_type` | begins a block which can handle thrown exceptions |
 | `catch` | `0x07` | tag : `varuint32` | begins a block when the exception `tag` is thrown |
 | `throw` | `0x08` | tag : `varuint32` | Throws an exception defined by the exception `tag` |
-| `rethrow` | `0x09` | catch_index : `varuint32` | re-throws the exception caught by the enclosing catch block |
+| `rethrow` | `0x09` | relativew_depth : `varuint32` | re-throws the exception caught by the corresponding try block |
 | `end` | `0x0b` | | end a block, loop, if,  and try |
 | `br` | `0x0c` | relative_depth : `varuint32` | break that targets an outer nested block |
 | `br_if` | `0x0d` | relative_depth : `varuint32` | conditional break that targets an outer nested block |

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -362,7 +362,7 @@ throws, and rethrows as follows:
 | `catch` | `0x07` | tag : `varuint32` | begins a block when the exception `tag` is thrown |
 | `throw` | `0x08` | tag : `varuint32` | Throws an exception defined by the exception `tag` |
 | `rethrow` | `0x09` | catch_index : `varuint32` | re-throws the exception caught by the enclosing catch block |
-| `end` | `0x0b` | | end a block, loop, if, try, catch, and catch default |
+| `end` | `0x0b` | | end a block, loop, if,  and try |
 | `br` | `0x0c` | relative_depth : `varuint32` | break that targets an outer nested block |
 | `br_if` | `0x0d` | relative_depth : `varuint32` | conditional break that targets an outer nested block |
 | `br_table` | `0x0e` | see below | branch table control flow construct |

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -110,7 +110,7 @@ it can begin with the `catch_all` instruction. If it begins with the
 catch block has no exception type, and is used to catch all exceptions not
 caught by any of the tagged catch blocks.
 
-Try blocks, like a control-flow blocks, have a _block type_. The block type of a
+Try blocks, like control-flow blocks, have a _block type_. The block type of a
 try block defines the values yielded by the evaluation the try block when either
 no exception is thrown, or the exception is successfully caught by one of its
 catch blocks, and the instructions within the catch block can recover from the
@@ -192,7 +192,7 @@ try
   ...
 catch 1
   ...
-  begin
+  block
     ...
     try
       ...
@@ -213,8 +213,11 @@ end
 In this example, `N` is used to disambiguate which caught exception is being
 rethrown. It could rethrow any of the three caught expceptions. Hence,
 `rethrow 0` corresponds to the exception caught by `catch 3`, `rethrow 1`
-corresponds to the exception caught by `catch 2`, and `rethrow 4` corresponds
+corresponds to the exception caught by `catch 2`, and `rethrow 3` corresponds
 to the exception caught by `catch 1`.
+
+Note that `rethrow 2` is not allowed because it does not reference a `try`
+instruction. Rather, it references a `block` instruction.
 
 ### Debugging
 
@@ -240,7 +243,7 @@ instructions ::=
   ...
   try resulttype instr* catch+ end |
   throw except_index |
-  rethrow catch_index
+  rethrow label
   
 catch ::=
   catch except_index inst* |
@@ -256,8 +259,8 @@ exception. Similarly, the `except_index` of the *throw* instruction is the tag f
 the constructed exception.  See [exception index space](#exception-index-space)
 for further clarification of exception tags.
 
-The `catch_index` of the `rethrow` instruction is the index to the corresponding
-catch that defines the exception to throw.
+The `label` of the `rethrow` instruction is the label to the corresponding try
+block, defining the catch to rethrow.
 
 ## Changes to Modules document.
 

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -38,7 +38,7 @@ must implement lightweight or heavyweight exceptions. Rather, it defers that
 choice to the runtime implementation.
 
 Exception handling is defined using *exceptions*, *try blocks*, *catch blocks*,
-and the instructions *throw* and *rethrow*.
+and the instructions `throw` and `rethrow`.
 
 ### Exceptions
 
@@ -120,7 +120,7 @@ In the initial implementation, try blocks may only yield 0 or 1 values.
 
 ### Throws
 
-The _throw_ instruction has a single immediate argument, an exception tag.  The
+The `throw` instruction has a single immediate argument, an exception tag.  The
 exception tag is used to define the data fields of the allocated exception. The
 values for the data fields must be on top of the operand stack, and must
 correspond to the exception type signature for the exception.
@@ -174,18 +174,18 @@ also be sure to also pop off the caught exception values.
 
 ### Rethrows
 
-The _rethrow_ instruction can only appear in the body of a catch block.  The
-_rethrow_ instruction always re-throws the exception caught by the referenced
+The `rethrow` instruction can only appear in the body of a catch block.  The
+`rethrow` instruction always re-throws the exception caught by an enclosing
 catch block. This allows the catch block to clean up state before the exception
 is passed back to the next enclosing try block.
 
-Associated with the _rethrow_ instruction is a _label_. The label is used to
+Associated with the `rethrow` instruction is a _label_. The label is used to
 disambiguate which exception is to be rethrown, when inside nested catch blocks.
 
 The label is the relative block depth to the corresponding try block for which
 the catching block appears.
 
-For example consider the following example:
+For example consider the following:
 
 ```
 try
@@ -250,12 +250,12 @@ catch ::=
   catch_all inst*
 ```
 
-Like the *block*, *loop*, and *if* instructions, the *try* instruction is a
-*structured* instruction, and is implicitly labeled. this allows branch
+Like the `block`, `loop`, and `if` instructions, the `try` instruction is a
+*structured* instruction, and is implicitly labeled. This allows branch
 instructions to exit try blocks.
 
 The `except_index` of the `catch` instruction is the exception tag for the caught
-exception. Similarly, the `except_index` of the *throw* instruction is the tag for
+exception. Similarly, the `except_index` of the `throw` instruction is the tag for
 the constructed exception.  See [exception index space](#exception-index-space)
 for further clarification of exception tags.
 
@@ -367,18 +367,17 @@ throws, and rethrows as follows:
 | `try` | `0x06` | sig : `block_type` | begins a block which can handle thrown exceptions |
 | `catch` | `0x07` | tag : `varuint32` | begins a block when the exception `tag` is thrown |
 | `throw` | `0x08` | tag : `varuint32` | Throws an exception defined by the exception `tag` |
-| `rethrow` | `0x09` | relativew_depth : `varuint32` | re-throws the exception caught by the corresponding try block |
-| `end` | `0x0b` | | end a block, loop, if,  and try |
+| `rethrow` | `0x09` | relative_depth : `varuint32` | re-throws the exception caught by the corresponding try block |
+| `end` | `0x0b` | | end a block, loop, if, and try |
 | `br` | `0x0c` | relative_depth : `varuint32` | break that targets an outer nested block |
 | `br_if` | `0x0d` | relative_depth : `varuint32` | conditional break that targets an outer nested block |
 | `br_table` | `0x0e` | see below | branch table control flow construct |
 | `return` | `0x0f` | | return zero or one value from this function |
 
-The *sig* fields of `block', 'if`, and `try` operators are block signatures
+The *sig* fields of `block`, `if`, and `try` operators are block signatures
 which describe their use of the operand stack.
 
 Note that the textual `catch_all` instruction is implemented using the
 `else` operator. Since the `else` operator is always unambiguous in the binary
 format, there is no need to tie up a separate opcode for the `catch_all`
 instruction.
-


### PR DESCRIPTION
Add section to describe the textual version of exception handling. Includes clarifying that try blocks are implicitly labeled. Fixes for issues #7 and #9.

Use 'catch default' in textual version and instruction 'else' in the binary format #9.

Disambiguate `rethrow` when in nested catch blocks (issue #10). 