### PR TITLE
Initial support for exceptions in spec interpreter

### DIFF
--- a/interpreter/spec/ast.ml
+++ b/interpreter/spec/ast.ml
@@ -96,6 +96,10 @@ and instr' =
   | Unary of unop                     (* unary numeric operator *)
   | Binary of binop                   (* binary numeric operator *)
   | Convert of cvtop                  (* conversion *)
+  | Throw of var                      (* throw exception *)
+  | Try of stack_type * instr list * catch list * catch_all option (* try ... catch ... catch_all block *)
+and catch = (var * instr list) Source.phrase
+and catch_all = instr list Source.phrase
 
 
 (* Globals & Functions *)
@@ -175,6 +179,12 @@ and import' =
   idesc : import_desc;
 }
 
+type exception_ = exception_' Source.phrase
+and exception_' =
+{
+  etype : func_type;
+}
+
 type module_ = module_' Source.phrase
 and module_' =
 {
@@ -188,6 +198,7 @@ and module_' =
   data : string segment list;
   imports : import list;
   exports : export list;
+  exceptions : exception_ list;
 }
 
 
@@ -205,6 +216,7 @@ let empty_module =
   data = [];
   imports = [];
   exports = [];
+  exceptions = [];
 }
 
 open Source

--- a/interpreter/spec/decode.ml
+++ b/interpreter/spec/decode.ml
@@ -652,8 +652,9 @@ let module_ s =
     s (len s) "function and code section have inconsistent lengths";
   let funcs =
     List.map2 Source.(fun t f -> {f.it with ftype = t} @@ f.at)
-      func_types func_bodies
-  in {types; tables; memories; globals; funcs; imports; exports; elems; data; start}
+      func_types func_bodies in
+  let exceptions = []
+  in {types; tables; memories; globals; funcs; imports; exports; elems; data; start; exceptions}
 
 
 let decode name bs = at module_ (stream name bs)

--- a/interpreter/spec/encode.ml
+++ b/interpreter/spec/encode.ml
@@ -362,6 +362,14 @@ let encode m =
       | Convert (F64 F64Op.DemoteF64) -> assert false
       | Convert (F64 F64Op.ReinterpretInt) -> op 0xbf
 
+      | Throw x -> op 0x08; var x
+      | Try (ts, es, cs, ca) ->
+        op 0x06; stack_type ts; list instr es;
+        match ca with
+        | Some es -> op 0x05; list instr es.it
+        | None -> ();
+        end_ ()
+
     let const c =
       list instr c.it; end_ ()
 

--- a/interpreter/spec/encode.ml
+++ b/interpreter/spec/encode.ml
@@ -365,9 +365,9 @@ let encode m =
       | Throw x -> op 0x08; var x
       | Try (ts, es, cs, ca) ->
         op 0x06; stack_type ts; list instr es;
-        match ca with
+        (match ca with
         | Some es -> op 0x05; list instr es.it
-        | None -> ();
+        | None -> ());
         end_ ()
 
     let const c =
@@ -387,6 +387,12 @@ let encode m =
     (* Type section *)
     let type_section ts =
       section 1 (vec func_type) ts (ts <> [])
+
+    (* Exception Section *)
+    let exception_ x =
+      func_type x.it.etype
+    let exception_section xs =
+      section 13 (vec exception_) xs (xs <> [])
 
     (* Import section *)
     let import_desc d =
@@ -505,6 +511,7 @@ let encode m =
       export_section m.it.exports;
       start_section m.it.start;
       elem_section m.it.elems;
+      exception_section m.it.exceptions;
       code_section m.it.funcs;
       data_section m.it.data
   end

--- a/interpreter/spec/operators.ml
+++ b/interpreter/spec/operators.ml
@@ -21,7 +21,9 @@ let br_table xs x = BrTable (xs, x)
 let return = Return
 let if_ ts es1 es2 = If (ts, es1, es2)
 let select = Select
-
+let throw_ x = Throw x
+let try_ tts tes ces = Try (tts, tes, [], Some ces)
+  
 let call x = Call x
 let call_indirect x = CallIndirect x
 

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -243,6 +243,10 @@ let rec instr e =
     | Unary op -> unop op, []
     | Binary op -> binop op, []
     | Convert op -> cvtop op, []
+    | Throw x -> "throw " ^ var x, []
+    | Try (ts, tes, _, ces) -> "try", list instr tes @ match ces with
+      | Some ces -> [Node ("catch_all", list instr ces.it)]
+      | None -> []
   in Node (head, inner)
 
 let const c =

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -166,6 +166,12 @@ rule token = parse
   | "get_global" { GET_GLOBAL }
   | "set_global" { SET_GLOBAL }
 
+  | "exception" { EXCEPTION }
+  | "try" { TRY }
+  | "catch" { CATCH }
+  | "catch_all" {CATCH_ALL }
+  | "throw" { THROW }
+
   | (nxx as t)".load"
     { LOAD (fun a o ->
         numop t (i32_load (opt a 2)) (i64_load (opt a 3))

--- a/test/core/exceptions.wast
+++ b/test/core/exceptions.wast
@@ -1,0 +1,21 @@
+(module
+ (exception $empty_exception (func))
+ 
+ (func (export "throw_unconditional")
+       (throw 0))
+
+ (func (export "try_catch_all") (result i32)
+       (try i32
+	(i32.const 1)
+	(catch_all
+	 (i32.const 0))))
+ 
+  (func (export "try_catch_all_throw") (result i32)
+       (try i32
+	(throw 0)
+	(catch_all
+	 (i32.const 0)))))
+
+(assert_trap (invoke "throw_unconditional") "webassembly exception")
+(assert_return (invoke "try_catch_all") (i32.const 1))
+(assert_return (invoke "try_catch_all_throw") (i32.const 0))


### PR DESCRIPTION
This change provides some initial support for exceptions in the spec interpreter.

We support basic exception declarations, `try` blocks, `catch_all` clauses and `throw`. This includes type checking, encoding, decoding, printing and execution.

There are still some limitations. Exceptions cannot yet take arguments. We do not support `catch` or `rethrow` yet. The allowed locations for the exceptions section is overly strict now, in part because the location is still an open question (#25).

Future PRs will add the missing functionality, but this is sufficient to give initial support and help clarify some of the details of the spec.