### PR TITLE
Clarify the relationship between the original proposal and Layer 1

### DIFF
--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -1,3 +1,11 @@
+THIS DOCUMENT IS OBSOLETE!
+
+Please see The new [Layer 1 MVP Proposal] instead.
+
+[Layer 1 MVP Proposal]: https://github.com/WebAssembly/exception-handling/blob/master/proposals/Layer-1.md
+
+The original proposal is preserved here for reference.
+
 # Exception handling
 
 There are four sections to this proposal

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -1,8 +1,8 @@
 THIS DOCUMENT IS OBSOLETE!
 
-Please see The new [Layer 1 MVP Proposal] instead.
+Please see The new [Level 1 MVP Proposal] instead.
 
-[Layer 1 MVP Proposal]: https://github.com/WebAssembly/exception-handling/blob/master/proposals/Layer-1.md
+[Level 1 MVP Proposal]: https://github.com/WebAssembly/exception-handling/blob/master/proposals/Level-1.md
 
 The original proposal is preserved here for reference.
 

--- a/proposals/Layer-1.md
+++ b/proposals/Layer-1.md
@@ -7,11 +7,13 @@ layers, and either:
 
 1. Improves readability by combining concepts in layer 1 into higher-level
    constructs, thereby reducing code size.
-
 2. Allow performance improvements in the VM.
-
 3. Introduce additional new functionality not available in layer 1.
-   
+
+This document supersedes the original [Exceptions Proposal].
+
+[Exceptions Proposal]: https://github.com/WebAssembly/exception-handling/blob/master/proposals/Exceptions.md
+
 ## Overview
 
 Exception handling allows code to break control flow when an exception is

--- a/proposals/Level-1.md
+++ b/proposals/Level-1.md
@@ -1,14 +1,14 @@
-# Layer 1 exception handling
+# Level 1 exception handling
 
-Layer 1 of exception handling is the MVP (minimal viable proposal) for
+Level 1 of exception handling is the MVP (minimal viable proposal) for
 implementing exceptions in WebAssembly. As such, it doesn't include higher-level
 concepts and structures. These concept and structures are introduced in later
-layers, and either:
+levels, and either:
 
-1. Improves readability by combining concepts in layer 1 into higher-level
+1. Improves readability by combining concepts in Level 1 into higher-level
    constructs, thereby reducing code size.
 2. Allow performance improvements in the VM.
-3. Introduce additional new functionality not available in layer 1.
+3. Introduce additional new functionality not available in Level 1.
 
 This document supersedes the original [Exceptions Proposal].
 


### PR DESCRIPTION
The original proposal has been significantly reworked based on experience trying to implement C++ exceptions. We are now pursuing a layered approach. This change clarifies that the old proposal is obsolete and for reference only, while Layer 1 represents the current MVP.