### PR TITLE
Combine throw and create

### DIFF
--- a/proposals/Level-1.md
+++ b/proposals/Level-1.md
@@ -188,7 +188,7 @@ If the selected catch block does not throw an exception, it must yield the
 value(s) expected by the corresponding catching try block. This includes popping
 the caught exception.
 
-Note that a caught exception value can be rethrown using the `throw`
+Note that a caught exception value can be rethrown using the `rethrow`
 instruction.
 
 ### Rethrowing an exception
@@ -327,10 +327,6 @@ which corresponds to the data fields of the exception.
 |-------|------|-------------|
 | `count` | `varuint32` | The number of types in the signature |
 | `type` | `value_type*` | The type of each element in the signature |
-
-Note: An `except_type` is not actually a type, just an exception definition that
-corresponds to an exception tag. It is listed under `Other types` for
-simplicity.
 
 ##### external_kind
 


### PR DESCRIPTION
Combine the throw and exception create instructions into a single 'throw' instruction. Add back from the original proposal the 'rethrow' instruction that can rethrow a caught exception.

Also cleans up cases some confusion of exception tags and exception indices. That is, the index is the static value used in the module, while the tag is the corresponding exception identifier for that index.