### PR TITLE
Add katex submodule to document/core/util

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "document/core/util/katex"]
+	path = document/core/util/katex
+	url = https://github.com/KaTeX/KaTeX/


### PR DESCRIPTION
To sync our spec with the reference type repo, we need this submodule
too.
cc @ioannad