### PR TITLE
Rethrow/br_on_exn traps when given nullref

### DIFF
--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -217,7 +217,8 @@ Note that a caught exception can be rethrown using the `rethrow` instruction.
 The `rethrow` instruction takes the exception associated with the `exnref` on
 top of the stack, and rethrows the exception. A rethrow has the same effect as a
 throw, other than an exception is not created. Rather, the referenced exception
-on top of the stack is popped and then thrown.
+on top of the stack is popped and then thrown. The `rethrow` instruction traps
+if the value on the top of the stack is of `nullref` type.
 
 ### Exception data extraction
 
@@ -271,7 +272,8 @@ end $end
 ```
 
 If the query fails, the control flow falls through, and no values are pushed
-onto the stack.
+onto the stack. The `br_on_exn` instruction traps if the value on the top of the
+stack is of `nullref` type.
 
 ### Stack traces
 

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -218,7 +218,7 @@ The `rethrow` instruction takes the exception associated with the `exnref` on
 top of the stack, and rethrows the exception. A rethrow has the same effect as a
 throw, other than an exception is not created. Rather, the referenced exception
 on top of the stack is popped and then thrown. The `rethrow` instruction traps
-if the value on the top of the stack is of `nullref` type.
+if the value on the top of the stack is null.
 
 ### Exception data extraction
 
@@ -273,7 +273,7 @@ end $end
 
 If the query fails, the control flow falls through, and no values are pushed
 onto the stack. The `br_on_exn` instruction traps if the value on the top of the
-stack is of `nullref` type.
+stack is null.
 
 ### Stack traces
 


### PR DESCRIPTION
Following the discussions in #90, it seems desirable and less
error-prone to make `rethrow` and `br_on_exn` trap in case the value on
top of the stack is of `nullref` type.

Closes #90.