### PR TITLE
Dependencies in proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ holds a
 [proposal](https://github.com/WebAssembly/exception-handling/blob/master/proposals/Exceptions.md) for
 adding exception handling to WebAssembly.
 
+The exception handling proposal depends on the [reference-types](https://github.com/WebAssembly/reference-types) proposal
+and on the [multi-value](https://github.com/WebAssembly/multi-value) proposal.
+
 The repository is a clone
-of [WebAssembly/spec](https://github.com/WebAssembly/spec), and is rebased on the spec of its dependent proposal [WebAssembly/reference-types](https://github.com/WebAssembly/reference-types).
+of [WebAssembly/spec](https://github.com/WebAssembly/spec), first rebased on the spec of its dependency [reference-types](https://github.com/WebAssembly/reference-types), and then merged with the other dependency [multi-value](https://github.com/WebAssembly/multi-value). 
 
-The remainder of the document is contents of the [README.md](https://github.com/WebAssembly/reference-types/blob/master/README.md)
-document of that repository.
+The remainder of the document has contents of the two README files of the dependencies: [reference-types/README.md](https://github.com/WebAssembly/reference-types/blob/master/README.md) and [multi-value/README.md](https://github.com/WebAssembly/multi-value/blob/master/README.md).
 
-# Reference Types Proposal for WebAssembly
+## Reference Types Proposal for WebAssembly
 
 [![Build Status](https://travis-ci.org/WebAssembly/reference-types.svg?branch=master)](https://travis-ci.org/WebAssembly/reference-types)
 
@@ -24,9 +26,20 @@ It is meant for discussion, prototype specification and implementation of a prop
 
 * See the [modified spec](https://webassembly.github.io/reference-types/core/) for details.
 
+## Multi-value Proposal for WebAssembly
+
+[![Build Status](https://travis-ci.org/WebAssembly/multi-value.svg?branch=master)](https://travis-ci.org/WebAssembly/multi-value)
+
+This repository is a clone of [github.com/WebAssembly/spec/](https://github.com/WebAssembly/spec/).
+It is meant for discussion, prototype specification and implementation of a proposal to add support for returning multiple values to WebAssembly.
+
+* See the [overview](proposals/multi-value/Overview.md) for a summary of the proposal.
+
+* See the [modified spec](https://webassembly.github.io/multi-value/) for details.
+
 Original `README` from upstream repository follows...
 
-# spec
+## spec
 
 This repository holds a prototypical reference implementation for WebAssembly,
 which is currently serving as the official specification. Eventually, we expect

--- a/README.md
+++ b/README.md
@@ -15,31 +15,31 @@ of [WebAssembly/spec](https://github.com/WebAssembly/spec), first rebased on the
 
 The remainder of the document has contents of the two README files of the dependencies: [reference-types/README.md](https://github.com/WebAssembly/reference-types/blob/master/README.md) and [multi-value/README.md](https://github.com/WebAssembly/multi-value/blob/master/README.md).
 
-## Reference Types Proposal for WebAssembly
+# Reference Types Proposal for WebAssembly
 
 [![Build Status](https://travis-ci.org/WebAssembly/reference-types.svg?branch=master)](https://travis-ci.org/WebAssembly/reference-types)
 
 This repository is a clone of [github.com/WebAssembly/spec/](https://github.com/WebAssembly/spec/).
 It is meant for discussion, prototype specification and implementation of a proposal to add support for basic reference types to WebAssembly.
 
-* See the [overview](proposals/reference-types/Overview.md) for a summary of the proposal.
+* See the [overview](https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md) for a summary of the proposal.
 
-* See the [modified spec](https://webassembly.github.io/reference-types/core/) for details.
+* See the [modified spec](https://webassembly.github.io/reference-types/) for details.
 
-## Multi-value Proposal for WebAssembly
+# Multi-value Proposal for WebAssembly
 
 [![Build Status](https://travis-ci.org/WebAssembly/multi-value.svg?branch=master)](https://travis-ci.org/WebAssembly/multi-value)
 
 This repository is a clone of [github.com/WebAssembly/spec/](https://github.com/WebAssembly/spec/).
 It is meant for discussion, prototype specification and implementation of a proposal to add support for returning multiple values to WebAssembly.
 
-* See the [overview](proposals/multi-value/Overview.md) for a summary of the proposal.
+* See the [overview](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md) for a summary of the proposal.
 
 * See the [modified spec](https://webassembly.github.io/multi-value/) for details.
 
 Original `README` from upstream repository follows...
 
-## spec
+# spec
 
 This repository holds a prototypical reference implementation for WebAssembly,
 which is currently serving as the official specification. Eventually, we expect

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -414,10 +414,10 @@ appear immediately after the global section.
 ##### Event section
 
 The `event` section is the named section 'event'. For ease of validation, this
-section comes after the [global
-section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#global-section)
-and before the [export
-section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#export-section).
+section comes after the [memory
+section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#memory-section)
+and before the [global
+section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#global-section).
 So the list of all sections will be:
 
 | Section Name | Code | Description |
@@ -427,8 +427,8 @@ So the list of all sections will be:
 | Function | `3` | Function declarations |
 | Table | `4` | Indirect function table and other tables |
 | Memory | `5` | Memory attributes |
-| Global | `6` | Global declarations |
 | Event | `13` | Event declarations |
+| Global | `6` | Global declarations |
 | Export | `7` | Exports |
 | Start | `8` | Start function declaration |
 | Element | `9` | Elements section |

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -15,10 +15,10 @@ This proposal requires the following proposals as prerequisites.
 - The [reference types proposal](https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md),
   since the [`exnref`](#the-exception-reference-data-type) type should be represented as a subtype of `anyref`.
 
-- The [multi value proposal](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md),
-  since otherwise the [`br_on_exn?`](#Exception data extraction) instruction would only work with exceptions which consume one value.
-  Moreover, by using [multi value](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md),
-  the [`try` blocks](#Try and catch blocks) may use values already in the stack.
+- The [multi-value proposal](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md),
+  since otherwise the [`br_on_exn`](#exception-data-extraction) instruction would only work with exceptions that contain one value.
+  Moreover, by using [multi-value](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md),
+  the [`try` blocks](#try-and-catch-blocks) may use values already in the stack, and also push multiple values onto the stack.
 
 ---
 

--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -10,10 +10,15 @@ on the second proposal, which uses first-class exception types, mainly based on
 the reasoning that it is more expressive and also more extendible to other kinds
 of events.
 
-This proposal requires the [reference types
-proposal](https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md)
-as a prerequisite, since the [`exnref`](#the-exception-reference-data-type) type
-should be represented as a subtype of `anyref`.
+This proposal requires the following proposals as prerequisites.
+
+- The [reference types proposal](https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md),
+  since the [`exnref`](#the-exception-reference-data-type) type should be represented as a subtype of `anyref`.
+
+- The [multi value proposal](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md),
+  since otherwise the [`br_on_exn?`](#Exception data extraction) instruction would only work with exceptions which consume one value.
+  Moreover, by using [multi value](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md),
+  the [`try` blocks](#Try and catch blocks) may use values already in the stack.
 
 ---
 
@@ -152,7 +157,7 @@ instruction. That is, a try block is sequence of instructions having the
 following form:
 
 ```
-try block_type
+try blocktype
   instruction*
 catch
   instruction*
@@ -316,7 +321,7 @@ document](https://github.com/WebAssembly/spec/blob/master/document/core/instruct
 The following rules are added to *instructions*:
 
 ```
-  try resulttype instruction* catch instruction* end |
+  try blocktype instruction* catch instruction* end |
   throw except_index |
   rethrow |
   br_on_exn label except_index
@@ -487,7 +492,7 @@ throws, and rethrows as follows:
 
 | Name | Opcode | Immediates | Description |
 | ---- | ---- | ---- | ---- |
-| `try` | `0x06` | sig : `block_type` | begins a block which can handle thrown exceptions |
+| `try` | `0x06` | sig : `blocktype` | begins a block which can handle thrown exceptions |
 | `catch` | `0x07` | | begins the catch block of the try block |
 | `throw` | `0x08` | index : `varint32` | Creates an exception defined by the exception `index`and then throws it |
 | `rethrow` | `0x09` | | Pops the `exnref` on top of the stack and throws it |


### PR DESCRIPTION
This PR adds the dependency to multi-value to the exception handling proposal text and to the README. 

I wrote an explanation of this dependency on the proposal text, but it's easier to see this once the verification and execution steps of `br_on_exn` and of `try` blocks are written out, as done [here](https://github.com/WebAssembly/exception-handling/issues/87#issuecomment-517216137) by @rossberg :

Validation:

```
ft = t1* -> t2*
C, label t2* |- e1* : t1* -> t2*
C, label t2* |- e2* : exnref -> t2*
-----------------------------------
C |- try ft e1* catch e2* end : ft

C_label(l) = C_exn(x) = t*
-------------------------------------
C |- br_on_exn l x : exnref -> exnref
```

Execution: 

```
v^n (try ft e1* catch e2* end)  -->  catch_m{e2*} (label_m{} v^n e1* end) end)
  (iff ft = t1^n -> t2^m)
S; F; catch_m{e*} T[v^n (throw a)] end  -->  S; F; label_m{} (exn a v^n) e* end
  (iff S_exn(a) = {typ t^n})

F; (exn a v*) (br_on_exn l x)  -->  F; v* (br l)
  (iff F_exn(x) = a)
```

Concerning the functionality of `try`-`catch` blocks, note especially the passing of `v^n` values into a `label_m{}`.
Concerning the functionality of `br_on_exn`, note especially the execution step resulting in a `br` instruction.

cc: @aheejin @Ms2ger @dhil 