### PR TITLE
Fix inconsistency in section order

### DIFF
--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -414,7 +414,7 @@ or defined:
 #### High-level structure
 
 A new `event` section is introduced and is named `event`. If included, it must
-appear immediately after the global section.
+appear immediately after the memory section.
 
 ##### Event section
 


### PR DESCRIPTION
In #90 it was decided to move the event section between memory section and global section. This change is reflected in the next paragraph, but not in the introduction.