### PR TITLE
Fix 'instruction syntax document' link

### DIFF
--- a/proposals/Exceptions.md
+++ b/proposals/Exceptions.md
@@ -314,7 +314,7 @@ out of memory are implementation-defined.)
 ## Changes to the text format
 
 This section describes change in the [instruction syntax
-document](https://github.com/WebAssembly/spec/blob/master/document/core/instructions.rst).
+document](https://github.com/WebAssembly/spec/blob/master/document/core/text/instructions.rst).
 
 ### New instructions
 


### PR DESCRIPTION
Currently, the link to the instruction syntax document results in a `404`.
This commit updates the link to point to a instructions.rst that exists
and hopefully is the correct one to link to.