### PR TITLE
Make attribute's encoding uint8

### DIFF
--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -401,7 +401,7 @@ Each tag type has the fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `attribute` | `varuint32` | The attribute of a tag. |
+| `attribute` | `uint8` | The attribute of a tag. |
 | `type` | `varuint32` | The type index for its corresponding type signature |
 
 ##### external_kind


### PR DESCRIPTION
This changes the encoding of the `attribute` field, which is preserved
for future use, from `varuint32` to `uint8`. `uint8` is simpler to
encode/decode and this attribute is not likely to need `varuint32` range
even in future.

Suggested in
https://github.com/WebAssembly/exception-handling/pull/161#discussion_r651745684.