### PR TITLE
Clarify catchless try in explainer

### DIFF
--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -115,8 +115,7 @@ A try-catch block contains zero or more `catch` blocks and zero or one
 `catch_all` block. All `catch` blocks must precede the `catch_all` block, if
 any. The `catch`/`catch_all` instructions (within the try construct) are called
 the _catching_ instructions. There may not be any `catch` or `catch_all` blocks
-after a `try`, in which case the `try` block does not catch any exceptions and
-rethrows them.
+after a `try`, in which case the `try` block does not catch any exceptions.
 
 The _body_ of the try block is the list of instructions before the first
 catching instruction. The _body_ of each catch block is the sequence of

--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -240,9 +240,9 @@ caught by `catch 1`. In wat format, the argument for the `rethrow` instructions
 can also be written as a label, like branches. So `rethrow 0` in the example
 above can also be written as `rethrow $l3`.
 
-Note that `rethrow 2` is not allowed because it does not reference a catch
-block. Rather, it references a `block` instruction, so it will result in a
-validation failure.
+Note that `rethrow 2` is not allowed because it does not refer to a `try` label
+with a catch block. Rather, it references a `block` instruction, so it will
+result in a validation failure.
 
 Note that the example below is a validation failure:
 ```
@@ -256,18 +256,6 @@ end
 ```
 The `rethrow` here references `try $l2`, but the `rethrow` is not within its
 `catch` block.
-
-Also, targetting a label of `catch`-less `try` or `try`-`delegate` is also a
-validation failure, because `rethrow` is not within a `catch` or `catch_all`.
-```
-try $l1
-  rethrow $l1  ;; validation failure!
-delegate
-
-try $l2
-  rethrow $l2  ;; validation failure!
-end
-```
 
 ### Try-delegate blocks
 

--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -241,7 +241,7 @@ can also be written as a label, like branches. So `rethrow 0` in the example
 above can also be written as `rethrow $l3`.
 
 Note that `rethrow 2` is not allowed because it does not refer to a `try` label
-with a catch block. Rather, it references a `block` instruction, so it will
+from within its catch block. Rather, it references a `block` instruction, so it will
 result in a validation failure.
 
 Note that the example below is a validation failure:
@@ -308,7 +308,7 @@ catching instructions (`catch`/`catch_all`/`delegate`) come after the
 `delegate` instruction.
 
 `delegate` can also target `catch`-less `try`, in which case the effect is the
-same as the `try` has catches but none of the catches are able to handle the
+same as if the `try` has catches but none of the catches are able to handle the
 exception.
 
 ### JS API

--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -241,8 +241,8 @@ can also be written as a label, like branches. So `rethrow 0` in the example
 above can also be written as `rethrow $l3`.
 
 Note that `rethrow 2` is not allowed because it does not refer to a `try` label
-from within its catch block. Rather, it references a `block` instruction, so it will
-result in a validation failure.
+from within its catch block. Rather, it references a `block` instruction, so it
+will result in a validation failure.
 
 Note that the example below is a validation failure:
 ```


### PR DESCRIPTION
- Removes the sentence that catchless `try` is the same as a regular
`block`, because it can be targetted by `delegate`.
- Improves a few sentences
- Adds examples for catchless try

Closes #164.