### PR TITLE
Update formal spec to (partially) implement the 3rd EH proposal

### DIFF
--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -217,13 +217,13 @@ Other instructions are checked in a similar manner.
        case (catch)
          let frame = pop_ctrl()
          error_if(frame.opcode =/= try || frame.opcode =/= catch)
-         let tagparams = tags.[x].type.params
+         let tagparams = tags[x].type.params
          push_ctrl(catch, tagparams , frame.end_types)
 
        case (catch_all)
          let frame = pop_ctrl()
          error_if(frame.opcode =/= try || frame.opcode =/= catch)
-         push_ctrl(catch_all, [] , frame.end_types)
+         push_ctrl(catch_all, [], frame.end_types)
 
        case (br n)
          error_if(ctrls.size() < n)

--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -247,7 +247,8 @@ Other instructions are checked in a similar manner.
          pop_vals(label_types(ctrls[m]))
          unreachable()
 
-
+.. todo::
+   Add a case for :code:`throw`.
 
 .. note::
    It is an invariant under the current WebAssembly instruction set that an operand of :code:`Unknown` type is never duplicated on the stack.

--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -217,8 +217,8 @@ Other instructions are checked in a similar manner.
        case (catch)
          let frame = pop_ctrl()
          error_if(frame.opcode =/= try || frame.opcode =/= catch)
-         let tagparams = tags[x].type.params
-         push_ctrl(catch, tagparams , frame.end_types)
+         let params = tags[x].type.params
+         push_ctrl(catch, params , frame.end_types)
 
        case (catch_all)
          let frame = pop_ctrl()

--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -25,7 +25,7 @@ Types are representable as an enumeration.
 
 .. code-block:: pseudo
 
-   type val_type = I32 | I64 | F32 | F64 | V128 | Funcref | Exnref | Externref
+   type val_type = I32 | I64 | F32 | F64 | V128 | Funcref | Externref
 
    func is_num(t : val_type | Unknown) : bool =
      return t = I32 || t = I64 || t = F32 || t = F64 || t = Unknown
@@ -34,7 +34,7 @@ Types are representable as an enumeration.
      return t = V128 || t = Unknown
 
    func is_ref(t : val_type | Unknown) : bool =
-     return t = Funcref || t = Exnref || t = Externref || t = Unknown
+     return t = Funcref || t = Externref || t = Unknown
 
 The algorithm uses two separate stacks: the *value stack* and the *control stack*.
 The former tracks the :ref:`types <syntax-valtype>` of operand values on the :ref:`stack <stack>`,
@@ -216,8 +216,14 @@ Other instructions are checked in a similar manner.
 
        case (catch)
          let frame = pop_ctrl()
-         error_if(frame.opcode =/= try)
-         push_ctrl(catch, [exnref], frame.end_types)
+         error_if(frame.opcode =/= try || frame.opcode =/= catch)
+         let tagparams = tags.[x].type.params
+         push_ctrl(catch, tagparams , frame.end_types)
+
+       case (catch_all)
+         let frame = pop_ctrl()
+         error_if(frame.opcode =/= try || frame.opcode =/= catch)
+         push_ctrl(catch_all, [] , frame.end_types)
 
        case (br n)
          error_if(ctrls.size() < n)

--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -76,7 +76,7 @@ Store
 
 .. math::
    \begin{array}{lclll}
-   \F{store\_init}() &=& \{ \SFUNCS~\epsilon,~ \SMEMS~\epsilon, ~\SEXNS~\epsilon,~ \STABLES~\epsilon,~ \SGLOBALS~\epsilon \} \\
+   \F{store\_init}() &=& \{ \SFUNCS~\epsilon,~ \SMEMS~\epsilon, ~\STAGS~\epsilon,~ \STABLES~\epsilon,~ \SGLOBALS~\epsilon \} \\
    \end{array}
 
 
@@ -539,26 +539,26 @@ Memories
    \end{array}
 
 
-.. index:: exception, exception address, store, exception instance, exception type, function type
-.. _embed-exn:
+.. index:: tag, tag address, store, tag instance, tag type, function type
+.. _embed-tag:
 
-Exceptions
-~~~~~~~~~~
+Tags
+~~~~
 
-.. _embedd-exn-alloc:
+.. _embedd-tag-alloc:
 
-:math:`\F{exn\_alloc}(\store, \exntype) : (\store, \exnaddr)`
+:math:`\F{tag\_alloc}(\store, \tagtype) : (\store, \tagaddr)`
 .............................................................
 
-1. Pre-condition: :math:`exntype` is :ref:`valid <valid-exntype>`.
+1. Pre-condition: :math:`tagtype` is :ref:`valid <valid-tagtype>`.
 
-2. Let :math:`\exnaddr` be the result of :ref:`allocating an exception <alloc-exn>` in :math:`\store` with :ref:`exception type <syntax-exntype>` :math:`\exntype`.
+2. Let :math:`\tagaddr` be the result of :ref:`allocating a tag <alloc-tag>` in :math:`\store` with :ref:`tag type <syntax-tagtype>` :math:`\tagtype`.
 
-3. Return the new store paired with :math:`\exnaddr`.
+3. Return the new store paired with :math:`\tagaddr`.
 
 .. math::
    \begin{array}{lclll}
-   \F{exn\_alloc}(S, \X{et}) &=& (S', \X{a}) && (\iff \allocexn(S, \X{et}) = S', \X{a}) \\
+   \F{tag\_alloc}(S, \X{tt}) &=& (S', \X{a}) && (\iff \alloctag(S, \X{tt}) = S', \X{a}) \\
    \end{array}
 
 

--- a/document/core/appendix/implementation.rst
+++ b/document/core/appendix/implementation.rst
@@ -24,7 +24,7 @@ However, it is expected that all implementations have "reasonably" large limits 
 Syntactic Limits
 ~~~~~~~~~~~~~~~~
 
-.. index:: abstract syntax, module, type, function, table, memory, global, element, data, import, export, parameter, result, local, structured control instruction, instruction, name, Unicode, character
+.. index:: abstract syntax, module, type, function, table, memory, tag, global, element, data, import, export, parameter, result, local, structured control instruction, instruction, name, Unicode, character
 .. _impl-syntax:
 
 Structure
@@ -36,7 +36,7 @@ An implementation may impose restrictions on the following dimensions of a modul
 * the number of :ref:`functions <syntax-func>` in a :ref:`module <syntax-module>`, including imports
 * the number of :ref:`tables <syntax-table>` in a :ref:`module <syntax-module>`, including imports
 * the number of :ref:`memories <syntax-mem>` in a :ref:`module <syntax-module>`, including imports
-* the number of :ref:`exceptions <syntax-exn>` in a :ref:`module <syntax-module>`, including imports
+* the number of :ref:`tags <syntax-tag>` in a :ref:`module <syntax-module>`, including imports
 * the number of :ref:`globals <syntax-global>` in a :ref:`module <syntax-module>`, including imports
 * the number of :ref:`element segments <syntax-elem>` in a :ref:`module <syntax-module>`
 * the number of :ref:`data segments <syntax-data>` in a :ref:`module <syntax-module>`
@@ -124,7 +124,7 @@ Restrictions on the following dimensions may be imposed during :ref:`execution <
 * the number of allocated :ref:`function instances <syntax-funcinst>`
 * the number of allocated :ref:`table instances <syntax-tableinst>`
 * the number of allocated :ref:`memory instances <syntax-meminst>`
-* the number of allocated :ref:`exception instances <syntax-exninst>`
+* the number of allocated :ref:`tag instances <syntax-taginst>`
 * the number of allocated :ref:`global instances <syntax-globalinst>`
 * the size of a :ref:`table instance <syntax-tableinst>`
 * the size of a :ref:`memory instance <syntax-meminst>`

--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -18,7 +18,7 @@ Construct                                        Judgement
 :ref:`Block type <valid-blocktype>`              :math:`\vdashblocktype \blocktype \ok`
 :ref:`Table type <valid-tabletype>`              :math:`\vdashtabletype \tabletype \ok`
 :ref:`Memory type <valid-memtype>`               :math:`\vdashmemtype \memtype \ok`
-:ref:`Exception type <valid-exntype>`            :math:`\vdashexntype \exntype \ok`
+:ref:`Tag type <valid-tagtype>`                  :math:`\vdashtagtype \tagtype \ok`
 :ref:`Global type <valid-globaltype>`            :math:`\vdashglobaltype \globaltype \ok`
 :ref:`External type <valid-externtype>`          :math:`\vdashexterntype \externtype \ok`
 :ref:`Instruction <valid-instr>`                 :math:`S;C \vdashinstr \instr : \stacktype`
@@ -27,7 +27,7 @@ Construct                                        Judgement
 :ref:`Function <valid-func>`                     :math:`C \vdashfunc \func : \functype`
 :ref:`Table <valid-table>`                       :math:`C \vdashtable \table : \tabletype`
 :ref:`Memory <valid-mem>`                        :math:`C \vdashmem \mem : \memtype`
-:ref:`Exception <valid-exn>`                     :math:`C \vdashexn \exn : \exntype`
+:ref:`Tag <valid-tag>`                           :math:`C \vdashtag \tag : \tagtype`
 :ref:`Global <valid-global>`                     :math:`C \vdashglobal \global : \globaltype`
 :ref:`Element segment <valid-elem>`              :math:`C \vdashelem \elem : \reftype`
 :ref:`Element mode <valid-elemmode>`             :math:`C \vdashelemmode \elemmode : \reftype`
@@ -56,7 +56,7 @@ Construct                                        Judgement
 :ref:`Function instance <valid-funcinst>`        :math:`S \vdashfuncinst \funcinst : \functype`
 :ref:`Table instance <valid-tableinst>`          :math:`S \vdashtableinst \tableinst : \tabletype`
 :ref:`Memory instance <valid-meminst>`           :math:`S \vdashmeminst \meminst : \memtype`
-:ref:`Exception instance <valid-exninst>`        :math:`S \vdashexninst \exninst : \exntype`
+:ref:`Tag instance <valid-taginst>`              :math:`S \vdashtaginst \taginst : \tagtype`
 :ref:`Global instance <valid-globalinst>`        :math:`S \vdashglobalinst \globalinst : \globaltype`
 :ref:`Element instance <valid-eleminst>`         :math:`S \vdasheleminst \eleminst \ok`
 :ref:`Data instance <valid-datainst>`            :math:`S \vdashdatainst \datainst \ok`
@@ -100,7 +100,7 @@ Construct                                        Judgement
 :ref:`Function instance <extend-funcinst>`       :math:`\vdashfuncinstextends \funcinst_1 \extendsto \funcinst_2`
 :ref:`Table instance <extend-tableinst>`         :math:`\vdashtableinstextends \tableinst_1 \extendsto \tableinst_2`
 :ref:`Memory instance <extend-meminst>`          :math:`\vdashmeminstextends \meminst_1 \extendsto \meminst_2`
-:ref:`Exception instance <extend-exninst>`       :math:`\vdashexninstextends \exninst_1 \extendsto \exninst_2`
+:ref:`Tag instance <extend-taginst>`             :math:`\vdashtaginstextends \taginst_1 \extendsto \taginst_2`
 :ref:`Global instance <extend-globalinst>`       :math:`\vdashglobalinstextends \globalinst_1 \extendsto \globalinst_2`
 :ref:`Element instance <extend-eleminst>`         :math:`\vdasheleminstextends \eleminst_1 \extendsto \eleminst_2`
 :ref:`Data instance <extend-datainst>`           :math:`\vdashdatainstextends \datainst_1 \extendsto \datainst_2`

--- a/document/core/appendix/index-types.rst
+++ b/document/core/appendix/index-types.rst
@@ -16,7 +16,7 @@ Category                                  Constructor                           
 (reserved)                                                                             :math:`\hex{7A}` .. :math:`\hex{71}`
 :ref:`Reference type <syntax-reftype>`    |FUNCREF|                                    :math:`\hex{70}` (-16 as |Bs7|)
 :ref:`Reference type <syntax-reftype>`    |EXTERNREF|                                  :math:`\hex{6F}` (-17 as |Bs7|)
-(reserved)                                                                             :math:`\hex{6D}` .. :math:`\hex{61}`
+(reserved)                                                                             :math:`\hex{6E}` .. :math:`\hex{61}`
 :ref:`Function type <syntax-functype>`    :math:`[\valtype^\ast] \to [\valtype^\ast]`  :math:`\hex{60}` (-32 as |Bs7|)
 (reserved)                                                                             :math:`\hex{5F}` .. :math:`\hex{41}`
 :ref:`Result type <syntax-resulttype>`    :math:`[\epsilon]`                           :math:`\hex{40}` (-64 as |Bs7|)

--- a/document/core/appendix/index-types.rst
+++ b/document/core/appendix/index-types.rst
@@ -16,13 +16,12 @@ Category                                  Constructor                           
 (reserved)                                                                             :math:`\hex{7A}` .. :math:`\hex{71}`
 :ref:`Reference type <syntax-reftype>`    |FUNCREF|                                    :math:`\hex{70}` (-16 as |Bs7|)
 :ref:`Reference type <syntax-reftype>`    |EXTERNREF|                                  :math:`\hex{6F}` (-17 as |Bs7|)
-:ref:`Reference type <syntax-reftype>`    |EXNREF|                                     :math:`\hex{6E}` (-18 as |Bs7|)
 (reserved)                                                                             :math:`\hex{6D}` .. :math:`\hex{61}`
 :ref:`Function type <syntax-functype>`    :math:`[\valtype^\ast] \to [\valtype^\ast]`  :math:`\hex{60}` (-32 as |Bs7|)
 (reserved)                                                                             :math:`\hex{5F}` .. :math:`\hex{41}`
 :ref:`Result type <syntax-resulttype>`    :math:`[\epsilon]`                           :math:`\hex{40}` (-64 as |Bs7|)
 :ref:`Table type <syntax-tabletype>`      :math:`\limits~\reftype`                     (none)
 :ref:`Memory type <syntax-memtype>`       :math:`\limits`                              (none)
-:ref:`Exception type <syntax-exntype>`    :math:`\functype`                            (none)
+:ref:`Tag type <syntax-tagtype>`          :math:`\functype`                            (none)
 :ref:`Global type <syntax-globaltype>`    :math:`\mut~\valtype`                        (none)
 ========================================  ===========================================  ===============================================================================

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -613,7 +613,7 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
 
 .. math::
    \frac{
-     \begin{array}{c}
+     \begin{array}{@{}c@{}}
      ((S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t'^\ast]\to[])^? \\
      ~~S; C,\CLABELS\,(\LCATCH~[t^\ast]) \vdashinstrseq \instr'^\ast : [(t'^\ast)^?] \to [t^\ast])^\ast \\
      S; C,\CLABELS\,[t^\ast] \vdashinstrseq \instr^\ast : [] \to [t^\ast] \\
@@ -635,7 +635,7 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
    \frac{
      S; C,\CLABELS\,[t^\ast] \vdashinstrseq \instr^\ast : [] \to [t^\ast]
      \qquad
-     |C.\CLABELS| \ge l
+     C.\CLABELS[l] = [t_0^\ast]
    }{
      S; C,\CLABELS\,[t^\ast] \vdashadmininstr \DELEGATEadm\{l\}~\instr^\ast~\END : [] \to [t^\ast]
    }

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -618,7 +618,7 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
      S; C,\CLABELS\,[t^\ast] \vdashinstrseq \instr^\ast : [] \to [t^\ast] \\
    \end{array}
    }{
-     S; C,\CLABELS\,[t^\ast] \vdashadmininstr \CATCHadm\{\tagaddr^?~\instr'^\ast\}^\ast~\instr^\ast~\END : [] \to [t^\ast]
+     S; C,\CLABELS\,[t^\ast] \vdashadmininstr \CATCHadm\{\tagaddr^?~{\instr'}^\ast\}^\ast~\instr^\ast~\END : [] \to [t^\ast]
    }
 
 
@@ -650,7 +650,7 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
    \frac{
      S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t'^\ast]\to[]
      \qquad
-     (val:t')^\ast
+     (val : t')^\ast
      \qquad
      S; C,\CLABELS\,(\catch~[t^\ast]) \vdashinstrseq \instr^\ast : [] \to [t^\ast]
    }{

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -67,14 +67,14 @@ Store Validity
 
 The following typing rules specify when a runtime :ref:`store <syntax-store>` :math:`S` is *valid*.
 A valid store must consist of
-:ref:`function <syntax-funcinst>`, :ref:`table <syntax-tableinst>`, :ref:`memory <syntax-meminst>`, :ref:`exception <syntax-exninst>`, :ref:`global <syntax-globalinst>`, and :ref:`module <syntax-moduleinst>` instances that are themselves valid, relative to :math:`S`.
+:ref:`function <syntax-funcinst>`, :ref:`table <syntax-tableinst>`, :ref:`memory <syntax-meminst>`, :ref:`tag <syntax-taginst>`, :ref:`global <syntax-globalinst>`, and :ref:`module <syntax-moduleinst>` instances that are themselves valid, relative to :math:`S`.
 
-To that end, each kind of instance is classified by a respective :ref:`function <syntax-functype>`, :ref:`table <syntax-tabletype>`, :ref:`memory <syntax-memtype>`, :ref:`exception <syntax-exntype>`, or :ref:`global <syntax-globaltype>` type.
+To that end, each kind of instance is classified by a respective :ref:`function <syntax-functype>`, :ref:`table <syntax-tabletype>`, :ref:`memory <syntax-memtype>`, :ref:`tag <syntax-tagtype>`, or :ref:`global <syntax-globaltype>` type.
 Module instances are classified by *module contexts*, which are regular :ref:`contexts <context>` repurposed as module types describing the :ref:`index spaces <syntax-index>` defined by a module.
 
 
 
-.. index:: store, function instance, table instance, memory instance, exception instance, global instance, function type, table type, memory type, exception type, global type
+.. index:: store, function instance, table instance, memory instance, tag instance, global instance, function type, table type, memory type, tag type, global type
 
 :ref:`Store <syntax-store>` :math:`S`
 .....................................
@@ -85,7 +85,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 
 * Each :ref:`memory instance <syntax-meminst>` :math:`\meminst_i` in :math:`S.\SMEMS` must be :ref:`valid <valid-meminst>` with some :ref:`memory type <syntax-memtype>` :math:`\memtype_i`.
 
-* Each :ref:`exception instance <syntax-exninst>` :math:`\exninst_i` in :math:`S.\SEXNS` must be :ref:`valid <valid-exninst>` with some :ref:`exception type <syntax-exntype>` :math:`\exntype_i`.
+* Each :ref:`tag instance <syntax-taginst>` :math:`\taginst_i` in :math:`S.\STAGS` must be :ref:`valid <valid-taginst>` with some :ref:`tag type <syntax-tagtype>` :math:`\tagtype_i`.
 
 * Each :ref:`global instance <syntax-globalinst>` :math:`\globalinst_i` in :math:`S.\SGLOBALS` must be :ref:`valid <valid-globalinst>` with some  :ref:`global type <syntax-globaltype>` :math:`\globaltype_i`.
 
@@ -105,7 +105,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
      \\
      (S \vdashmeminst \meminst : \memtype)^\ast
      \qquad
-     (S \vdashexninst \exninst : \exntype)^\ast
+     (S \vdashtaginst \taginst : \tagtype)^\ast
      \\
      (S \vdashglobalinst \globalinst : \globaltype)^\ast
      \\
@@ -117,7 +117,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
        \SFUNCS~\funcinst^\ast,
        \STABLES~\tableinst^\ast,
        \SMEMS~\meminst^\ast,
-       \SEXNS~\exninst^\ast,
+       \STAGS~\taginst^\ast,
        \\
        \SGLOBALS~\globalinst^\ast,
        \SELEMS~\eleminst^\ast,
@@ -259,21 +259,21 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
    }
 
 
-.. index:: exception type, exception instance, exception tag, function type
-.. _valid-exninst:
+.. index:: tag type, tag instance, function type
+.. _valid-taginst:
 
-:ref:`Exception Instances <syntax-exninst>` :math:`\{ \EITYPE~\exntype \}`
-...........................................................................
+:ref:`Tag Instances <syntax-taginst>` :math:`\{ \TAGITYPE~\tagtype \}`
+......................................................................
 
-* The :ref:`exception type <syntax-exntype>` :math:`\exntype` must be :ref:`valid <valid-exntype>`.
+* The :ref:`tag type <syntax-tagtype>` :math:`\tagtype` must be :ref:`valid <valid-tagtype>`.
 
-* Then the exception instance is valid with :ref:`exception type <syntax-exntype>` :math:`\exntype`.
+* Then the tag instance is valid with :ref:`tag type <syntax-tagtype>` :math:`\tagtype`.
 
 .. math::
    \frac{
-     \vdashexntype \exntype \ok
+     \vdashtagtype \tagtype \ok
    }{
-     S \vdashexninst \{ \EITYPE~\exntype \} : \exntype
+     S \vdashtaginst \{ \TAGITYPE~\tagtype \} : \tagtype
    }
 
 
@@ -365,7 +365,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 
 * For each :ref:`memory address <syntax-memaddr>` :math:`\memaddr_i` in :math:`\moduleinst.\MIMEMS`, the :ref:`external value <syntax-externval>` :math:`\EVMEM~\memaddr_i` must be :ref:`valid <valid-externval-mem>` with some :ref:`external type <syntax-externtype>` :math:`\ETMEM~\memtype_i`.
 
-* For each :ref:`exception address <syntax-exnaddr>` :math:`\exnaddr_i` in :math:`\moduleinst.\MIEXNS`, the :ref:`external value <syntax-externval>` :math:`\EVEXN~\exnaddr_i` must be :ref:`valid <valid-externval-exn>` with some :ref:`external type <syntax-externtype>` :math:`\ETEXN~\exntype_i`.
+* For each :ref:`tag address <syntax-tagaddr>` :math:`\tagaddr_i` in :math:`\moduleinst.\MITAGS`, the :ref:`external value <syntax-externval>` :math:`\EVTAG~\tagaddr_i` must be :ref:`valid <valid-externval-tag>` with some :ref:`external type <syntax-externtype>` :math:`\ETTAG~\tagtype_i`.
 
 * For each :ref:`global address <syntax-globaladdr>` :math:`\globaladdr_i` in :math:`\moduleinst.\MIGLOBALS`, the :ref:`external value <syntax-externval>` :math:`\EVGLOBAL~\globaladdr_i` must be :ref:`valid <valid-externval-global>` with some :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~\globaltype_i`.
 
@@ -383,12 +383,12 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 
 * Let :math:`\memtype^\ast` be the concatenation of all :math:`\memtype_i` in order.
 
-* Let :math:`\exntype^\ast` be the concatenation of all :math:`\exntype_i` in order.
+* Let :math:`\tagtype^\ast` be the concatenation of all :math:`\tagtype_i` in order.
 
 * Let :math:`\globaltype^\ast` be the concatenation of all :math:`\globaltype_i` in order.
 
 * | Then the module instance is valid with :ref:`context <context>`
-  | :math:`\{\CTYPES~\functype^\ast, \CFUNCS~{\functype'}^\ast, \CTABLES~\tabletype^\ast, \CMEMS~\memtype^\ast, \CEXNS~\exntype^\ast, \CGLOBALS~\globaltype^\ast\}`.
+  | :math:`\{\CTYPES~\functype^\ast, \CFUNCS~{\functype'}^\ast, \CTABLES~\tabletype^\ast, \CMEMS~\memtype^\ast, \CTAGS~\tagtype^\ast, \CGLOBALS~\globaltype^\ast\}`.
 
 .. math::
    ~\\[-1ex]
@@ -402,7 +402,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
      \\
      (S \vdashexternval \EVMEM~\memaddr : \ETMEM~\memtype)^\ast
      \qquad
-     (S \vdashexternval \EVEXN~\exnaddr : \ETEXN~\exntype)^\ast
+     (S \vdashexternval \EVTAG~\tagaddr : \ETTAG~\tagtype)^\ast
      \\
      (S \vdashexternval \EVGLOBAL~\globaladdr : \ETGLOBAL~\globaltype)^\ast
      \\
@@ -421,7 +421,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
        \MIFUNCS & \funcaddr^\ast, \\
        \MITABLES & \tableaddr^\ast, \\
        \MIMEMS & \memaddr^\ast, \\
-       \MIEXNS & \exnaddr^\ast, \\
+       \MITAGS & \tagaddr^\ast, \\
        \MIGLOBALS & \globaladdr^\ast, \\
        \MIELEMS & \elemaddr^\ast, \\
        \MIDATAS & \dataaddr^\ast, \\
@@ -431,7 +431,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
          \CFUNCS & {\functype'}^\ast, \\
          \CTABLES & \tabletype^\ast, \\
          \CMEMS & \memtype^\ast, \\
-         \CEXNS & \exntype^\ast \\
+         \CTAGS & \tagtype^\ast \\
          \CGLOBALS & \globaltype^\ast ~\}
          \end{array}
        \end{array}
@@ -586,65 +586,75 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
    }
 
 
-.. index:: exception address, exception type, function type, value type, exception tag
+.. index:: throw, throw context, tag address
 
-:math:`\REFEXNADDR~\exnaddr~\val^\ast`
-......................................
+:math:`\THROWadm~\tagaddr`
+..........................
 
-* The :ref:`external exception value <syntax-externval>` :math:`\EVEXN~\exnaddr` must be :ref:`valid <valid-externval-exn>` with :ref:`external exception type <syntax-externtype>` :math:`\ETEXN~[t^\ast]\to[]`.
+* The :ref:`external tag value <syntax-externval>` :math:`\EVTAG~\tagaddr` must be :ref:`valid <valid-externval-tag>` with :ref:`external tag type <syntax-externtype>` :math:`\ETTAG~[t^\ast]\to[]`.
 
-* Each :ref:`value <syntax-val>` :math:`\val_i` in :math:`\val^\ast` must be :ref:`valid <valid-val>` with :ref:`value type <syntax-valtype>` :math:`t_i` in :math:`t^\ast`.
-
-* Then the instruction is valid with type :math:`[] \to [\EXNREF]`.
+* Then the instruction is valid with type :math:`[t_1^\ast t^\ast] \to [t_2^\ast]` for any sequences of :ref:`value types <syntax-valtype>` :math:`t_1^\ast` and :math:`t_2^\ast`.
 
 .. math::
    \frac{
-     S \vdashexternval \EVEXN~\exnaddr : \ETEXN~[t^\ast]\to[]
-     \qquad
-     (S \vdashval \val : t)^\ast
+     S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t^\ast]\to[]
    }{
-     S; C \vdashadmininstr \REFEXNADDR~\exnaddr~\val^\ast : [] \to [\EXNREF]
-   }
-
-
-.. index:: throw, throw context, exception address, exception tag
-
-:math:`\THROWADDR~\exnaddr`
-...........................
-
-* The :ref:`external exception value <syntax-externval>` :math:`\EVEXN~\exnaddr` must be :ref:`valid <valid-externval-exn>` with :ref:`external exception type <syntax-externtype>` :math:`\ETEXN~[t^\ast]\to[]`.
-
-* Then the instruction is valid with type :math:`[t_1^\ast t^\ast] -> [t_2^\ast]` for any sequences of :ref:`value types <syntax-valtype>` :math:`t_1^\ast` and :math:`t_2^\ast`.
-
-.. math::
-   \frac{
-     S \vdashexternval \EVEXN~\exnaddr : \ETEXN~[t^\ast]\to[]
-   }{
-     S; C \vdashadmininstr \THROWADDR~\exnaddr : [t_1^\ast t^\ast] \to [t_2^\ast]
+     S; C \vdashadmininstr \THROWadm~\tagaddr : [t_1^\ast t^\ast] \to [t_2^\ast]
    }
 
 
 .. index:: catch, throw context
 
-:math:`\CATCH_n\{ \instr_0^\ast \} \instr^\ast \END`
-....................................................
+:math:`\CATCHadm\{\tagaddr^?~\instr'^\ast\}^\ast~\instr^\ast~\END`
+..................................................................
 
-* The instruction sequence :math:`\instr_0^\ast` must be :ref:`valid <valid-instr-seq>` with a type of the form :math:`[\EXNREF] \to [t^n]`.
+**TODO: add prose**
 
-* Let :math:`C'` be the same :ref:`context <context>` as :math:`C`, but with the :ref:`result type <syntax-resulttype>` :math:`[t^n]` prepended to the |CLABELS| vector.
-
-* Under context :math:`C'`,
-  the instruction sequence :math:`\instr^\ast` must be :ref:`valid <valid-instr-seq>` with type :math:`[] \to [t^n]`.
-
-* Then the compound instruction is valid with type :math:`[] \to [t^n]`.
 
 .. math::
    \frac{
-     S; C \vdashinstrseq \instr_0^\ast : [\EXNREF] \to [t^n]
-     \qquad
-     S; C,\CLABELS\,[t^n] \vdashinstrseq \instr^\ast : [] \to [t^n]
+     \begin{array}{c}
+     ((S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t'^\ast]\to[])^?~~\land~~S; C,\CLABELS\,(\catch~[t^\ast]) \vdashinstrseq \instr'^\ast : [(t'^\ast)^?] \to [t^\ast])^\ast \\
+     S; C,\CLABELS\,[t^\ast] \vdashinstrseq \instr^\ast : [] \to [t^\ast] \\
+   \end{array}
    }{
-     S; C \vdashadmininstr \CATCH_n\{\instr_0^\ast\}~\instr^\ast~\END : [] \to [t^n]
+     S; C,\CLABELS\,[t^\ast] \vdashadmininstr \CATCHadm\{\tagaddr^?~\instr'^\ast\}^\ast~\instr^\ast~\END : [] \to [t^\ast]
+   }
+
+
+.. index:: delegate, throw context
+
+:math:`\DELEGATEadm\{l\}~\instr^\ast~\END`
+..........................................
+
+**TODO: add prose**
+
+.. math::
+   \frac{
+     S; C,\CLABELS\,[t^\ast] \vdashinstrseq \instr^\ast : [] \to [t^\ast]
+     \qquad
+     |C.\CLABELS| \ge l
+   }{
+     S; C,\CLABELS\,[t^\ast] \vdashadmininstr \DELEGATEadm\{l\}~\instr^\ast~\END : [] \to [t^\ast]
+   }
+
+
+.. index:: caught, throw context
+
+:math:`\CAUGHTadm\{\tagaddr~\val^\ast\}~\instr^\ast~\END`
+.........................................................
+
+**TODO: add prose**
+
+.. math::
+   \frac{
+     S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t'^\ast]\to[]
+     \qquad
+     (val:t')^\ast
+     \qquad
+     S; C,\CLABELS\,(\catch~[t^\ast]) \vdashinstrseq \instr^\ast : [] \to [t^\ast]
+   }{
+     S; C,\CLABELS\,[t^\ast] \vdashadmininstr \CAUGHTadm\{\tagaddr~\val^\ast\}~\instr^\ast~\END : [] \to [t^\ast]
    }
 
 
@@ -738,7 +748,7 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
 
 * The length of :math:`S.\SMEMS` must not shrink.
 
-* The length of :math:`S.\SEXNS` must not shrink.
+* The length of :math:`S.\STAGS` must not shrink.
 
 * The length of :math:`S.\SGLOBALS` must not shrink.
 
@@ -752,7 +762,7 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
 
 * For each :ref:`memory instance <syntax-meminst>` :math:`\meminst_i` in the original :math:`S.\SMEMS`, the new memory instance must be an :ref:`extension <extend-meminst>` of the old.
 
-* For each :ref:`exception instance <syntax-exninst>` :math:`\exninst_i` in the original :math:`S.\SEXNS`, the new exception instance must be an :ref:`extension <extend-exninst>` of the old.
+* For each :ref:`tag instance <syntax-taginst>` :math:`\taginst_i` in the original :math:`S.\STAGS`, the new tag instance must be an :ref:`extension <extend-taginst>` of the old.
 
 * For each :ref:`global instance <syntax-globalinst>` :math:`\globalinst_i` in the original :math:`S.\SGLOBALS`, the new global instance must be an :ref:`extension <extend-globalinst>` of the old.
 
@@ -772,9 +782,9 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
      S_1.\SMEMS = \meminst_1^\ast &
      S_2.\SMEMS = {\meminst'_1}^\ast~\meminst_2^\ast &
      (\vdashmeminstextends \meminst_1 \extendsto \meminst'_1)^\ast \\
-     S_1.\SEXNS = \exninst_1^\ast &
-     S_2.\SEXNS = {\exninst'_1}^\ast~\exninst_2^\ast &
-     (\vdashexninstextends \exninst_1 \extendsto \exninst'_1)^\ast \\
+     S_1.\STAGS = \taginst_1^\ast &
+     S_2.\STAGS = {\taginst'_1}^\ast~\taginst_2^\ast &
+     (\vdashtaginstextends \taginst_1 \extendsto \taginst'_1)^\ast \\
      S_1.\SGLOBALS = \globalinst_1^\ast &
      S_2.\SGLOBALS = {\globalinst'_1}^\ast~\globalinst_2^\ast &
      (\vdashglobalinstextends \globalinst_1 \extendsto \globalinst'_1)^\ast \\
@@ -841,18 +851,18 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
    }
 
 
-.. index:: exception instance
-.. _extend-exninst:
+.. index:: tag instance
+.. _extend-taginst:
 
-:ref:`Exception Instance <syntax-exninst>` :math:`\exninst`
-...........................................................
+:ref:`Tag Instance <syntax-taginst>` :math:`\taginst`
+.....................................................
 
-* An exception instance must remain unchanged.
+* A tag instance must remain unchanged.
 
 .. math::
    \frac{
    }{
-     \vdashexninstextends \exninst \extendsto \exninst
+     \vdashtaginstextends \taginst \extendsto \taginst
    }
 
 

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -608,13 +608,14 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
 :math:`\CATCHadm\{\tagaddr^?~\instr'^\ast\}^\ast~\instr^\ast~\END`
 ..................................................................
 
-**TODO: add prose**
-
+.. todo::
+   Add prose.
 
 .. math::
    \frac{
      \begin{array}{c}
-     ((S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t'^\ast]\to[])^?~~\land~~S; C,\CLABELS\,(\catch~[t^\ast]) \vdashinstrseq \instr'^\ast : [(t'^\ast)^?] \to [t^\ast])^\ast \\
+     ((S \vdashexternval \EVTAG~\tagaddr : \ETTAG~[t'^\ast]\to[])^? \\
+     ~~S; C,\CLABELS\,(\LCATCH~[t^\ast]) \vdashinstrseq \instr'^\ast : [(t'^\ast)^?] \to [t^\ast])^\ast \\
      S; C,\CLABELS\,[t^\ast] \vdashinstrseq \instr^\ast : [] \to [t^\ast] \\
    \end{array}
    }{
@@ -627,7 +628,8 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
 :math:`\DELEGATEadm\{l\}~\instr^\ast~\END`
 ..........................................
 
-**TODO: add prose**
+.. todo::
+   Add prose.
 
 .. math::
    \frac{
@@ -644,7 +646,8 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
 :math:`\CAUGHTadm\{\tagaddr~\val^\ast\}~\instr^\ast~\END`
 .........................................................
 
-**TODO: add prose**
+.. todo::
+   Add prose.
 
 .. math::
    \frac{
@@ -652,7 +655,7 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
      \qquad
      (val : t')^\ast
      \qquad
-     S; C,\CLABELS\,(\catch~[t^\ast]) \vdashinstrseq \instr^\ast : [] \to [t^\ast]
+     S; C,\CLABELS\,(\LCATCH~[t^\ast]) \vdashinstrseq \instr^\ast : [] \to [t^\ast]
    }{
      S; C,\CLABELS\,[t^\ast] \vdashadmininstr \CAUGHTadm\{\tagaddr~\val^\ast\}~\instr^\ast~\END : [] \to [t^\ast]
    }

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -21,7 +21,7 @@ The only exception are :ref:`structured control instructions <binary-instr-contr
 Control Instructions
 ~~~~~~~~~~~~~~~~~~~~
 
-:ref:`Control instructions <syntax-instr-control>` have varying encodings. For structured instructions, the instruction sequences forming nested blocks are  separated or terminated with explicit opcodes for |END|, |ELSE|, |CATCH|, |CATCHALL|, and |DELEGATE|.
+:ref:`Control instructions <syntax-instr-control>` have varying encodings. For structured instructions, the instruction sequences forming nested blocks are separated or terminated with explicit opcodes for |END|, |ELSE|, |CATCH|, |CATCHALL|, and |DELEGATE|.
 
 :ref:`Block types <syntax-blocktype>` are encoded in special compressed form, by either the byte :math:`\hex{40}` indicating the empty type, as a single :ref:`value type <binary-valtype>`, or as a :ref:`type index <binary-typeidx>` encoded as a positive :ref:`signed integer <binary-sint>`.
 

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -13,7 +13,7 @@ The only exception are :ref:`structured control instructions <binary-instr-contr
    Gaps in the byte code ranges for encoding instructions are reserved for future extensions.
 
 
-.. index:: control instructions, structured control, label, block, branch, result type, value type, block type, label index, function index, exception index, type index, vector, polymorphism, LEB128
+.. index:: control instructions, structured control, exception handling, label, block, branch, result type, value type, block type, label index, function index, tag index, type index, vector, polymorphism, LEB128
    pair: binary format; instruction
    pair: binary format; block type
 .. _binary-instr-control:
@@ -21,7 +21,7 @@ The only exception are :ref:`structured control instructions <binary-instr-contr
 Control Instructions
 ~~~~~~~~~~~~~~~~~~~~
 
-:ref:`Control instructions <syntax-instr-control>` have varying encodings. For structured instructions, the instruction sequences forming nested blocks are terminated with explicit opcodes for |END|, |ELSE|, and |CATCH|.
+:ref:`Control instructions <syntax-instr-control>` have varying encodings. For structured instructions, the instruction sequences forming nested blocks are  separated or terminated with explicit opcodes for |END|, |ELSE|, |CATCH|, |CATCHALL|, and |DELEGATE|.
 
 :ref:`Block types <syntax-blocktype>` are encoded in special compressed form, by either the byte :math:`\hex{40}` indicating the empty type, as a single :ref:`value type <binary-valtype>`, or as a :ref:`type index <binary-typeidx>` encoded as a positive :ref:`signed integer <binary-sint>`.
 
@@ -34,7 +34,6 @@ Control Instructions
 .. _binary-try:
 .. _binary-throw:
 .. _binary-rethrow:
-.. _binary-br_on_exn:
 .. _binary-br:
 .. _binary-br_if:
 .. _binary-br_table:
@@ -61,11 +60,14 @@ Control Instructions
        \hex{05}~~(\X{in}_2{:}\Binstr)^\ast~~\hex{0B}
        &\Rightarrow& \IF~\X{bt}~\X{in}_1^\ast~\ELSE~\X{in}_2^\ast~\END \\ &&|&
      \hex{06}~~\X{bt}{:}\Bblocktype~~(\X{in}_1{:}\Binstr)^\ast~~
-       \hex{07}~~(\X{in}_2{:}\Binstr)^\ast~~\hex{0B}
-       &\Rightarrow& \TRY~\X{bt}~\X{in}_1^\ast~\CATCH~\X{in}_2^\ast~\END \\ &&|&
-     \hex{08}~~x{:}\Bexnidx &\Rightarrow& \THROW~x \\ &&|&
-     \hex{09} &\Rightarrow& \RETHROW \\ &&|&
-     \hex{0A}~~l{:}\Blabelidx~~x{:}\Bexnidx &\Rightarrow& \BRONEXN~l~x \\ &&|&
+       (\hex{07}~~x{:}\Btagidx~~(\X{in}_2{:}\Binstr)^\ast)^\ast~~
+       (\hex{19}~~(\X{in}_3{:}\Binstr)^\ast)^?~~\hex{0B}
+       &\Rightarrow& \TRY~\X{bt}~\X{in}_1^\ast~(\CATCH~x~\X{in}_2^\ast)^\ast~
+       (\CATCHALL~\X{in}_3^\ast)^?\END \\ &&|&
+     \hex{06}~~\X{bt}{:}\Bblocktype~~(\X{in}{:}\Binstr)^\ast~~\hex{18}~~l{:}\Blabelidx
+       &\Rightarrow& \TRY~\X{bt}~\X{in}^\ast~\DELEGATE~l \\ &&|&
+     \hex{08}~~x{:}\Btagidx &\Rightarrow& \THROW~x \\ &&|&
+     \hex{09}~~l{:}\Blabelidx &\Rightarrow& \RETHROW~l \\ &&|&
      \hex{0C}~~l{:}\Blabelidx &\Rightarrow& \BR~l \\ &&|&
      \hex{0D}~~l{:}\Blabelidx &\Rightarrow& \BRIF~l \\ &&|&
      \hex{0E}~~l^\ast{:}\Bvec(\Blabelidx)~~l_N{:}\Blabelidx

--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -9,12 +9,12 @@ except that :ref:`function definitions <syntax-func>` are split into two section
    This separation enables *parallel* and *streaming* compilation of the functions in a module.
 
 
-.. index:: index, type index, function index, table index, memory index, exception index, global index, element index, data index, local index, label index
+.. index:: index, type index, function index, table index, memory index, tag index, global index, element index, data index, local index, label index
    pair: binary format; type index
    pair: binary format; function index
    pair: binary format; table index
    pair: binary format; memory index
-   pair: binary format; exception index
+   pair: binary format; tag index
    pair: binary format; global index
    pair: binary format; element index
    pair: binary format; data index
@@ -24,7 +24,7 @@ except that :ref:`function definitions <syntax-func>` are split into two section
 .. _binary-funcidx:
 .. _binary-tableidx:
 .. _binary-memidx:
-.. _binary-exnidx:
+.. _binary-tagidx:
 .. _binary-globalidx:
 .. _binary-elemidx:
 .. _binary-dataidx:
@@ -43,7 +43,7 @@ All :ref:`indices <syntax-index>` are encoded with their respective value.
    \production{function index} & \Bfuncidx &::=& x{:}\Bu32 &\Rightarrow& x \\
    \production{table index} & \Btableidx &::=& x{:}\Bu32 &\Rightarrow& x \\
    \production{memory index} & \Bmemidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{exception index} & \Bexnidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{tag index} & \Btagidx &::=& x{:}\Bu32 &\Rightarrow& x \\
    \production{global index} & \Bglobalidx &::=& x{:}\Bu32 &\Rightarrow& x \\
    \production{element index} & \Belemidx &::=& x{:}\Bu32 &\Rightarrow& x \\
    \production{data index} & \Bdataidx &::=& x{:}\Bu32 &\Rightarrow& x \\
@@ -103,7 +103,7 @@ Id  Section
 10  :ref:`code section <binary-codesec>`           
 11  :ref:`data section <binary-datasec>`           
 12  :ref:`data count section <binary-datacountsec>`
-13  :ref:`exception section <binary-exnsec>`
+13  :ref:`tag section <binary-tagsec>`
 ==  ===============================================
 
 
@@ -150,7 +150,7 @@ It decodes into a vector of :ref:`function types <syntax-functype>` that represe
    \end{array}
 
 
-.. index:: ! import section, import, name, function type, table type, memory type, global type, exception type
+.. index:: ! import section, import, name, function type, table type, memory type, global type, tag type
    pair: binary format; import
    pair: section; import
 .. _binary-import:
@@ -175,7 +175,7 @@ It decodes into a vector of :ref:`imports <syntax-import>` that represent the |M
      \hex{01}~~\X{tt}{:}\Btabletype &\Rightarrow& \IDTABLE~\X{tt} \\ &&|&
      \hex{02}~~\X{mt}{:}\Bmemtype &\Rightarrow& \IDMEM~\X{mt} \\ &&|&
      \hex{03}~~\X{gt}{:}\Bglobaltype &\Rightarrow& \IDGLOBAL~\X{gt} \\ &&|&
-     \hex{04}~~\X{et}{:}\Bexn &\Rightarrow& \IDEXN~\X{et} \\
+     \hex{04}~~\X{tt}{:}\Btag &\Rightarrow& \IDTAG~\X{tt} \\
    \end{array}
 
 
@@ -262,7 +262,7 @@ It decodes into a vector of :ref:`globals <syntax-global>` that represent the |M
    \end{array}
 
 
-.. index:: ! export section, export, name, index, function index, table index, memory index, exception index, global index
+.. index:: ! export section, export, name, index, function index, table index, memory index, tag index, global index
    pair: binary format; export
    pair: section; export
 .. _binary-export:
@@ -287,7 +287,7 @@ It decodes into a vector of :ref:`exports <syntax-export>` that represent the |M
      \hex{01}~~x{:}\Btableidx &\Rightarrow& \EDTABLE~x \\ &&|&
      \hex{02}~~x{:}\Bmemidx &\Rightarrow& \EDMEM~x \\ &&|&
      \hex{03}~~x{:}\Bglobalidx &\Rightarrow& \EDGLOBAL~x \\ &&|&
-     \hex{04}~~x{:}\Bexnidx &\Rightarrow& \EDEXN~x \\
+     \hex{04}~~x{:}\Btagidx &\Rightarrow& \EDTAG~x \\
    \end{array}
 
 
@@ -490,29 +490,29 @@ It decodes into an optional :ref:`u32 <syntax-uint>` that represents the number 
    instead of deferring validation.
 
 
-.. index:: ! exception section, exception, exception type, function type index
-   pair: binary format; exception
-   pair: section; exception
-.. _binary-exn:
-.. _binary-exnsec:
+.. index:: ! tag section, tag, tag type, function type index, exception tag
+   pair: binary format; tag
+   pair: section; tag
+.. _binary-tag:
+.. _binary-tagsec:
 
-Exception Section
-~~~~~~~~~~~~~~~~~
+Tag Section
+~~~~~~~~~~~
 
-The *exception section* has the id 13.
-It decodes into a vector of :ref:`exceptions <syntax-exn>` that represent the |MEXNS|
+The *tag section* has the id 13.
+It decodes into a vector of :ref:`tags <syntax-tag>` that represent the |MTAGS|
 component of a :ref:`module <syntax-module>`.
 
 .. math::
    \begin{array}{llclll}
-   \production{exception section} & \Bexnsec &::=&
-     \X{exception}^\ast{:}\Bsection_{13}(\Bvec(\Bexn)) &\Rightarrow& \X{exception}^\ast \\
-   \production{exception} & \Bexn &::=&
-     \hex{00}~~\X{x}{:}\Btypeidx &\Rightarrow& \{ \ETYPE~\X{x} \} \\
+   \production{tag section} & \Btagsec &::=&
+     \X{tag}^\ast{:}\Bsection_{13}(\Bvec(\Btag)) &\Rightarrow& \X{tag}^\ast \\
+   \production{tag} & \Btag &::=&
+     \hex{00}~~\X{x}{:}\Btypeidx &\Rightarrow& \{ \TAGTYPE~\X{x} \} \\
    \end{array}
 
 
-.. index:: module, section, type definition, function type, function, table, memory, exception, global, element, data, start function, import, export, context, version
+.. index:: module, section, type definition, function type, function, table, memory, tag, global, element, data, start function, import, export, context, version
    pair: binary format; module
 .. _binary-magic:
 .. _binary-version:
@@ -554,7 +554,7 @@ Furthermore, it must be present if any :math:`data index <syntax-dataidx>` occur
      \Bcustomsec^\ast \\ &&&
      \mem^\ast{:\,}\Bmemsec \\ &&&
      \Bcustomsec^\ast \\ &&&
-     \exn^\ast{:\,}\Bexnsec \\ &&&
+     \tag^\ast{:\,}\Btagsec \\ &&&
      \Bcustomsec^\ast \\ &&&
      \global^\ast{:\,}\Bglobalsec \\ &&&
      \Bcustomsec^\ast \\ &&&
@@ -576,7 +576,7 @@ Furthermore, it must be present if any :math:`data index <syntax-dataidx>` occur
        \MFUNCS~\func^n, \\
        \MTABLES~\table^\ast, \\
        \MMEMS~\mem^\ast, \\
-       \MEXNS~\exn^\ast, \\
+       \MTAGS~\tag^\ast, \\
        \MGLOBALS~\global^\ast, \\
        \MELEMS~\elem^\ast, \\
        \MDATAS~\data^m, \\

--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -201,7 +201,7 @@ Tag Types
      \hex{00}~~ft{:}\Bfunctype &\Rightarrow& ft \\
    \end{array}
 
-The |Bfunctype| of a tag must have an empty result, and it is used to characterise exceptions.
+The |Bfunctype| of a tag is used to characterise exceptions.
 The :math:`\hex{00}` bit signifies an exception and is currently the only allowed value.
 
 .. note::

--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -58,8 +58,7 @@ Reference Types
    \begin{array}{llclll@{\qquad\qquad}l}
    \production{reference type} & \Breftype &::=&
      \hex{70} &\Rightarrow& \FUNCREF \\ &&|&
-     \hex{6F} &\Rightarrow& \EXTERNREF \\ &&|&
-     \hex{6E} &\Rightarrow& \EXNREF \\
+     \hex{6F} &\Rightarrow& \EXTERNREF \\
    \end{array}
 
 
@@ -187,22 +186,23 @@ Global Types
    \end{array}
 
 
-.. index:: exception type, function type
-   pair: binary format; exception type
-.. _binary-exntype:
+.. index:: tag type, function type, exception tag
+   pair: binary format; tag type
+.. _binary-tagtype:
 
-Exception Types
-~~~~~~~~~~~~~~~
+Tag Types
+~~~~~~~~~
 
-:ref:`Exception types <syntax-exntype>` are encoded by their function type.
+:ref:`Tag types <syntax-tagtype>` are encoded by their function type.
 
 .. math::
    \begin{array}{llclll}
-   \production{exception type} & \Bexntype &::=&
+   \production{tag type} & \Btagtype &::=&
      \hex{00}~~ft{:}\Bfunctype &\Rightarrow& ft \\
    \end{array}
 
-The |Bfunctype| of an exception must have an empty result.
+The |Bfunctype| of a tag must have an empty result, and it is used to characterise exceptions.
+The :math:`\hex{00}` bit signifies an exception and is currently the only allowed value.
 
 .. note::
    In future versions of WebAssembly,

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2620,35 +2620,42 @@ Control Instructions
    \end{array}
 
 
-.. _exec-try:
+.. _exec-try-catch:
 
-:math:`\TRY~\blocktype~\instr_1^\ast~\CATCH~\instr_2^\ast~\END`
-...............................................................
+:math:`\TRY~\blocktype~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?~\END`
+....................................................................................................
 
-1. Assert: due to :ref:`validation <valid-blocktype>`, :math:`\expand_F(\blocktype)` is defined.
-
-2. Let :math:`[t_1^n] \to [t_2^m]` be the :ref:`function type <syntax-functype>` :math:`\expand_F(\blocktype)`.
-
-3. Assert: due to :ref:`validation <valid-try>`, there are at least :math:`n` values on the top of the stack.
-
-4. Pop the values :math:`\val^n` from the stack.
-
-5. Let :math:`L` be the label whose arity is :math:`m` and whose continuation is the end of the |TRY| instruction.
-
-6. Let :math:`H` be the exception handler whose arity is :math:`m` and whose continuation is the beginning of :math:`\instr_2^\ast`.
-
-7. :ref:`Enter <exec-handler-enter>` the exception handler `H`.
-
-8. :ref:`Enter <exec-instr-seq-enter>` the block :math:`\val^n~\instr_1^\ast` with label :math:`L`.
+**TODO: Add prose**
 
 .. math::
    ~\\[-1ex]
-   \begin{array}{lcl@{\qquad}}
-   F; \val^n~(\TRY~\X{bt}~\instr_1^\ast~\CATCH~\instr_2^\ast~\END &\stepto&
-   \CATCHN_m\{\instr_2\}~(\LABEL_m \{\}~\val^n~\instr_1^\ast~\END)~\END \\
-   \hspace{5ex}(\iff \expand_F(\X{bt}) = [t_1^n] \to [t_2^m]) &&\\
+   \begin{array}{l}
+   F; \val^n~(\TRY~\X{bt}~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?~\END
+   \quad \stepto \\
+   \qquad F; \LABEL_m\{\}~(\CATCHadm\{a~\instr_2^\ast\}^\ast\{\epsilon~\instr_3\}^?~\val^n~\instr_1^\ast~\END)~\END \\
+   (\iff \expand_F(\X{bt}) = [t_1^n] \to [t_2^m] \land (F.\AMODULE.\MITAGS[x]=a)^\ast)
    \end{array}
 
+
+.. _exec-try-delegate:
+
+:math:`\TRY~\blocktype~\instr^\ast~\DELEGATE~l`
+...............................................
+
+**TODO: Add prose**
+
+.. math::
+   ~\\[-1ex]
+   \begin{array}{lcl}
+   F; \val^n~(\TRY~\X{bt}~\instr^\ast~\DELEGATE~l) &\stepto&
+   F; \LABEL_m\{\}~(\DELEGATEadm\{l\}~\val^n~\instr^\ast~\END)~\END \\
+   && (\iff \expand_F(\X{bt}) = [t_1^n] \to [t_2^m])
+   \end{array}
+
+.. note::
+   Note that the last reduction step above is similar to the :ref:`reduction <exec-br>` of :math:`\BR~l`, but also doing a throw after it breaks.
+
+   There is a subtle difference though. The instruction :math:`\BR~l` searches for the :math:`l+1` surrounding block and breaks out after that block. Because :math:`\DELEGATEadm\{l\}` is always wrapped in its own label, with the :ref:`same lookup <exec-br>` as for :math:`\BR~l` we end up breaking inside the :math:`l+1` surrounding block and throwing there. So if that :math:`l+1` surrounding block is a try, we end up throwing in its "try code", and thus correctly getting delegated to that try's handlers.
 
 .. _exec-throw:
 
@@ -2657,81 +2664,31 @@ Control Instructions
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-throw>`, :math:`F.\AMODULE.\MIEXNS[x]` exists.
+2. Assert: due to :ref:`validation <valid-throw>`, :math:`F.\AMODULE.\MITAGS[x]` exists.
 
-3. Let :math:`a` be the :ref:`exception address <syntax-exnaddr>` :math:`F.\AMODULE.\MIEXNS[x]`.
+3. Let :math:`a` be the :ref:`tag address <syntax-tagaddr>` :math:`F.\AMODULE.\MITAGS[x]`.
 
-4. :ref:`Throw <exec-throwaddr>` an exception with :ref:`exception address <syntax-exnaddr>` :math:`a`.
+4. :ref:`Throw <exec-throwadm>` an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`.
 
 .. math::
    ~\\[-1ex]
    \begin{array}{lclr@{\qquad}l}
-   \THROW~x &\stepto& \THROWADDR~a & (\iff F.\AMODULE.\MIEXNS[x] = a) \\
+   \THROW~x &\stepto& \THROWadm~a & (\iff F.\AMODULE.\MITAGS[x] = a) \\
    \end{array}
 
 
 .. _exec-rethrow:
 
-:math:`\RETHROW`
-................
+:math:`\RETHROW~l`
+..................
 
-1. Assert: due to :ref:`validation <valid-rethrow>`, there is a value with :ref:`reference type <syntax-reftype>` :math:`\EXNREF` on top of the stack.
-
-2. Pop the :math:`\EXNREF` value from the stack.
-
-3. If the :math:`\EXNREF` value is :math:`\REFNULL~\EXNREF` then:
-
-   a. Trap.
-
-4. Assert: :math:`\EXNREF` is of the form :math:`(\REFEXNADDR~a~\val^\ast)`.
-
-5. Put the values :math:`\val^\ast` on the stack.
-
-6. :ref:`Throw <exec-throwaddr>`  an exception with :ref:`exception address <syntax-exnaddr>` :math:`a`.
+**TODO: Add prose**
 
 .. math::
    ~\\[-1ex]
    \begin{array}{lclr@{\qquad}}
-     (\REFNULL~\EXNREF)~\RETHROW &\stepto& \TRAP \\
-     (\REFEXNADDR~a~\val^\ast)~\RETHROW &\stepto& \val^\ast~(\THROWADDR~a) \\
-   \end{array}
-
-
-.. _exec-br_on_exn:
-
-:math:`\BRONEXN~l~x`
-....................
-
-1. Assert: due to :ref:`validation <valid-br_on_exn>`, there is a value with :ref:`reference type <syntax-reftype>` :math:`\EXNREF` on top of the stack.
-
-2. Pop the :math:`\EXNREF` value from the stack.
-
-3. If the :math:`\EXNREF` value is :math:`\REFNULL~\EXNREF` then:
-
-   a. Trap.
-
-4. Assert: :math:`\EXNREF` is of the form :math:`(\REFEXNADDR~a~\val^\ast)`.
-
-5. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
-
-6. Assert: due to :ref:`validation <valid-br_on_exn>`, :math:`F.\AMODULE.\MIEXNS[x]` exists.
-
-7. If :math:`F.\AMODULE.\MIEXNS[x]=a`, then:
-
-   a. Put the values :math:`\val^\ast` on the stack.
-
-   b. :ref:`Execute <exec-br>` the instruction :math:`(\BR~l)`.
-
-8. Else:
-
-   a. Put the value :math:`(\REFEXNADDR~a~\val^\ast)` back on the stack.
-
-.. math::
-   ~\\[-1ex]
-   \begin{array}{lclr@{\qquad}l}
-     F; (\REFNULL~\EXNREF)~\BRONEXN~l~x &\stepto& F; \TRAP \\
-     F; (\REFEXNADDR~a~\val^\ast)~\BRONEXN~l~x &\stepto& F; \val^\ast~(\BR~l)     & (\iff F.\AMODULE.\MIEXNS[x] = a) \\
-     F; (\REFEXNADDR~a~\val^\ast)~\BRONEXN~l~x &\stepto& F; (\REFEXNADDR~a~\val^\ast) & (\iff F.\AMODULE.\MIEXNS[x] \neq a) \\
+   \CAUGHTadm\{a~\val^n\}~\XB^l[\RETHROW~l]~\END &\stepto&
+   \CAUGHTadm\{a~\val^n\}~\XB^l[\val^n~(\THROWadm~a)]~\END \\
    \end{array}
 
 
@@ -3005,15 +2962,16 @@ When the end of a block is reached without a jump, exception, or trap aborting i
    Therefore, execution of a loop falls off the end, unless a backwards branch is performed explicitly.
 
 
-.. index:: exception handling, throw context
+.. index:: exception handling, throw context, tag, exception tag
    pair: handling; exception
 
-.. _exec-catch:
+.. _exec-catchadm:
+.. _exec-delegateadm:
 
 Exception Handling
 ~~~~~~~~~~~~~~~~~~
 
-The following auxiliary rules define the semantics of entering and exiting exception handlers through :ref:`try <syntax-try>` instructions and handling thrown exceptions.
+The following auxiliary rules define the semantics of entering and exiting :ref:`exception handlers <syntax-handler>` through :ref:`try <syntax-try>` instructions, and handling thrown exceptions.
 
 .. _exec-handler-enter:
 
@@ -3023,9 +2981,10 @@ Entering an exception handler :math:`H`
 1. Push :math:`H` onto the stack.
 
 .. note::
-   No formal reduction rule is needed for installing an exception handler
+   No formal reduction rule is needed for installing an exception :ref:`handler <syntax-handler>`
    because it is an :ref:`administrative instruction <syntax-instr-admin>`
    that the :ref:`try <syntax-try>` instruction reduced to directly.
+
 
 .. _exec-handler-exit:
 
@@ -3044,60 +3003,47 @@ When the end of a :ref:`try <syntax-try>` instruction is reached without a jump,
 
 5. Push :math:`\val^m` back to the stack.
 
-6. Jump to the position after the |END| of the originating |TRY| instruction associated with the handler :math:`H`.
+6. Jump to the position after the |END| of the administrative instruction associated with the handler :math:`H`.
 
 .. math::
    ~\\[-1ex]
    \begin{array}{lcl@{\qquad}l}
-   \CATCHN_m\{instr^\ast\}~\val^m~\END &\stepto& \val^m
+   \CATCHadm\{a^?~\instr^\ast\}^\ast~\val^m~\END &\stepto& \val^m \\
+   \DELEGATEadm\{l\}~\val^m~\END &\stepto& \val^m
    \end{array}
 
 
-.. _exec-throwaddr:
+.. _exec-throwadm:
 
-Throwing an exception with :ref:`exception address <syntax-exnaddr>` :math:`a`
-..............................................................................
+Throwing an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`
+........................................................................
 
-When a throw or a rethrow occurs, labels and call frames are popped if necessary,
-until an exception handler is found on the top of the stack.
-
-1. Assert: due to validation, :math:`S.\SEXNS[a]` exists.
-
-2. Let :math:`[t^n] \to [t'^m]` be the :ref:`exception type <syntax-exntype>` :math:`S.\SEXNS[a].\EITYPE`.
-
-3. Assert: due to :ref:`validation <valid-try>`, there are :math:`n` values on the top of the stack.
-
-4. Pop the :math:`n` values :math:`\val^n` from the stack.
-
-5. While the stack is not empty and the top of the stack is not an exception handler, do:
-
-   a. Pop the top element from the stack.
-
-6. Assert: The stack is now either empty or there is an exception handler on the top.
-
-
-7. If there is an exception handler :math:`\CATCHN_m\{\instr^\ast\}` on the top of the stack, then:
-
-   a. Pop the exception handler from the stack.
-
-   b. Let :math:`L` be the label whose arity is :math:`m` and whose continuation is the end of the |TRY| instruction associated with the handler.
-
-   c. Push the label :math:`L` on the stack.
-
-   d. Enter the block :math:`\instr^\ast` with label :math:`L`.
-
-   e. Push the :ref:`exception reference <syntax-refexnaddr>` :math:`(\REFEXNADDR~a~\val^n)` to the stack.
-8. Else the stack is empty.
-
-9. *TODO: return TBA administrative instruction for the unresolved throw.*
+**TODO: add prose**
 
 
 .. math::
    \begin{array}{rcl}
-   S;~F;~\CATCHN_m\{\instr^\ast\}~\XT[\val^n~(\THROWADDR~a)]~\END &\stepto&
-      S;~F;~\LABEL_m\{\}~(\REFEXNADDR~a~\val^n)~{\instr}^\ast~\END \\
-   && \hspace{-12ex} (\iff S.\SEXNS[a]=\{\ETYPE~[t^n]\to[]\}) \\
-   %   S;\val^n~(\THROWADDR~a) & \stepto & TBA \\
+   \CATCHadm\{a_1^?~\instr^\ast\}\{a'^?~\instr'^\ast\}^\ast~\XT[\val^n~(\THROWadm~a)]~\END &\stepto&
+   \CATCHadm\{a'^?~\instr'^\ast\}^\ast~\XT[\val^n~(\THROWadm~a)]~\END  \\
+   && (\iff a_1^? \neq \epsilon \land a_1^? \neq a) \\
+   S;~\CATCHadm\{a_1^?~\instr^\ast\}\{a'^?~\instr'^\ast\}^\ast~\XT[\val^n~(\THROWadm~a)]~\END &\stepto&
+   S;~\CAUGHTadm\{a~\val^n\}~(\val^n)?~\instr^\ast~\END \\
+   && (\iff~(a_1^? = \epsilon \lor a_1^? = a)~\land\\
+   && \ S.\STAGS[a].\TAGITYPE = [t^n]\to[]) \\
+   \LABEL_n\{\}~\XB^l[\DELEGATEadm\{l\}~\XT[\val^n~(\THROWadm~a)]~\END]~\END &\stepto&
+   \val^n~(\THROWadm~a)  \\
+   \end{array}
+
+.. _exec-caughtadm:
+
+Holding a caught exception with |CAUGHTadm|
+...........................................
+
+**TODO: add prose describing the administrative** |CAUGHTadm|
+
+.. math::
+   \begin{array}{rcl}
+   \CAUGHTadm\{a~\val^n\}~\val^m~\END  &\stepto& \val^m
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2625,7 +2625,8 @@ Control Instructions
 :math:`\TRY~\blocktype~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?~\END`
 ....................................................................................................
 
-**TODO: Add prose**
+.. todo::
+   Add prose for the |TRY| - |CATCH| - |CATCHALL| execution step.
 
 .. math::
    ~\\[-1ex]
@@ -2642,7 +2643,8 @@ Control Instructions
 :math:`\TRY~\blocktype~\instr^\ast~\DELEGATE~l`
 ...............................................
 
-**TODO: Add prose**
+.. todo::
+   Add prose for the |TRY| - |DELEGATE| execution step.
 
 .. math::
    ~\\[-1ex]
@@ -2652,10 +2654,6 @@ Control Instructions
    && (\iff \expand_F(\X{bt}) = [t_1^n] \to [t_2^m])
    \end{array}
 
-.. note::
-   Note that the last reduction step above is similar to the :ref:`reduction <exec-br>` of :math:`\BR~l`, but also doing a throw after it breaks.
-
-   There is a subtle difference though. The instruction :math:`\BR~l` searches for the :math:`l+1` surrounding block and breaks out after that block. Because :math:`\DELEGATEadm\{l\}` is always wrapped in its own label, with the :ref:`same lookup <exec-br>` as for :math:`\BR~l` we end up breaking inside the :math:`l+1` surrounding block and throwing there. So if that :math:`l+1` surrounding block is a try, we end up throwing in its "try code", and thus correctly getting delegated to that try's handlers.
 
 .. _exec-throw:
 
@@ -2682,7 +2680,8 @@ Control Instructions
 :math:`\RETHROW~l`
 ..................
 
-**TODO: Add prose**
+.. todo::
+   Add prose for the |RETHROW| execution step.
 
 .. math::
    ~\\[-1ex]
@@ -3017,7 +3016,8 @@ When the end of a :ref:`try <syntax-try>` instruction is reached without a jump,
 Throwing an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`
 ........................................................................
 
-**TODO: add prose**
+.. todo::
+   Add prose for the following execution steps.
 
 
 .. math::
@@ -3033,12 +3033,17 @@ Throwing an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`
    \XT[(\THROWadm~a)]  \\
    \end{array}
 
+
+.. todo::
+   Add explainer note.
+
 .. _exec-caughtadm:
 
 Holding a caught exception with |CAUGHTadm|
 ...........................................
 
-**TODO: add prose describing the administrative** |CAUGHTadm|
+.. todo::
+   Add prose describing the administrative |CAUGHTadm| execution step.
 
 .. math::
    \begin{array}{rcl}

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2632,7 +2632,7 @@ Control Instructions
    \begin{array}{l}
    F; \val^n~(\TRY~\X{bt}~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?~\END
    \quad \stepto \\
-   \qquad F; \LABEL_m\{\}~(\CATCHadm\{a~\instr_2^\ast\}^\ast\{\epsilon~\instr_3\}^?~\val^n~\instr_1^\ast~\END)~\END \\
+   \qquad F; \LABEL_m\{\}~(\CATCHadm\{a~\instr_2^\ast\}^\ast\{\epsilon~\instr_3\ast\}^?~\val^n~\instr_1^\ast~\END)~\END \\
    (\iff \expand_F(\X{bt}) = [t_1^n] \to [t_2^m] \land (F.\AMODULE.\MITAGS[x]=a)^\ast)
    \end{array}
 
@@ -2983,8 +2983,7 @@ Entering an exception handler :math:`H`
 .. note::
    No formal reduction rule is needed for installing an exception :ref:`handler <syntax-handler>`
    because it is an :ref:`administrative instruction <syntax-instr-admin>`
-   that the :ref:`try <syntax-try>` instruction reduced to directly.
-
+   that the :ref:`try <syntax-try>` instruction reduces to directly.
 
 .. _exec-handler-exit:
 
@@ -3023,15 +3022,15 @@ Throwing an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`
 
 .. math::
    \begin{array}{rcl}
-   \CATCHadm\{a_1^?~\instr^\ast\}\{a'^?~\instr'^\ast\}^\ast~\XT[\val^n~(\THROWadm~a)]~\END &\stepto&
-   \CATCHadm\{a'^?~\instr'^\ast\}^\ast~\XT[\val^n~(\THROWadm~a)]~\END  \\
+   \CATCHadm\{a_1^?~\instr^\ast\}\{a'^?~\instr'^\ast\}^\ast~\XT[(\THROWadm~a)]~\END &\stepto&
+   \CATCHadm\{a'^?~\instr'^\ast\}^\ast~\XT[(\THROWadm~a)]~\END  \\
    && (\iff a_1^? \neq \epsilon \land a_1^? \neq a) \\
    S;~\CATCHadm\{a_1^?~\instr^\ast\}\{a'^?~\instr'^\ast\}^\ast~\XT[\val^n~(\THROWadm~a)]~\END &\stepto&
    S;~\CAUGHTadm\{a~\val^n\}~(\val^n)?~\instr^\ast~\END \\
    && (\iff~(a_1^? = \epsilon \lor a_1^? = a)~\land\\
    && \ S.\STAGS[a].\TAGITYPE = [t^n]\to[]) \\
-   \LABEL_n\{\}~\XB^l[\DELEGATEadm\{l\}~\XT[\val^n~(\THROWadm~a)]~\END]~\END &\stepto&
-   \val^n~(\THROWadm~a)  \\
+   \LABEL_n\{\}~\XB^l[\DELEGATEadm\{l\}~\XT[(\THROWadm~a)]~\END]~\END &\stepto&
+   \XT[(\THROWadm~a)]  \\
    \end{array}
 
 .. _exec-caughtadm:

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -68,22 +68,22 @@ The following auxiliary typing rules specify this typing relation relative to a 
    }
 
 
-.. index:: exception type, exception address, exception tag, function type
-.. _valid-externval-exn:
+.. index:: tag type, tag address, exception tag, function type
+.. _valid-externval-tag:
 
-:math:`\EVEXN~a`
+:math:`\EVTAG~a`
 ................
 
-* The store entry :math:`S.\SEXNS[a]` must exist.
+* The store entry :math:`S.\STAGS[a]` must exist.
 
-* Let :math:`\exntype` be the function type :math:`S.\SEXNS[a].\EITYPE`.
+* Let :math:`\tagtype` be the function type :math:`S.\STAGS[a].\TAGITYPE`.
 
-* Then :math:`\EVEXN~a` is valid with :ref:`external type <syntax-externtype>` :math:`\ETEXN~\exntype`.
+* Then :math:`\EVTAG~a` is valid with :ref:`external type <syntax-externtype>` :math:`\ETTAG~\tagtype`.
 
 .. math::
    \frac{
    }{
-     S \vdashexternval \EVEXN~a : \ETEXN~(S.\SEXNS[a].\EITYPE)
+     S \vdashexternval \EVTAG~a : \ETTAG~(S.\STAGS[a].\TAGITYPE)
    }
 
 
@@ -169,32 +169,13 @@ The following auxiliary typing rules specify this typing relation relative to a 
    }
 
 
-:ref:`Exception References <syntax-refexnaddr>` :math:`\REFEXNADDR~a~\val^n`
-............................................................................
-
-* The external value :math:`\EVEXN~a` must be valid with :ref:`exception type <syntax-exntype>` :math:`[t^n]\to[]`.
-
-* Each value :math:`val_i` in :math:`\val^n` must have type :math:`t_i` in :math:`t^n`.
-
-* The value is valid with :ref:`reference type <syntax-reftype>` :math:`\EXNREF`.
-
-.. math::
-   \frac{
-     S \vdashexternval \EVEXN~a : [t^n]\to[]
-   \qquad
-    (S \vdashval \val : t)^n
-   }{
-     S \vdashval \REFEXNADDR~a~\val^n : \EXNREF
-   }
-
-
 .. index:: ! allocation, store, address
 .. _alloc:
 
 Allocation
 ~~~~~~~~~~
 
-New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tableinst>`, :ref:`memories <syntax-meminst>`, :ref:`exceptions <syntax-exninst>`, and :ref:`globals <syntax-globalinst>` are *allocated* in a :ref:`store <syntax-store>` :math:`S`, as defined by the following auxiliary functions.
+New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tableinst>`, :ref:`memories <syntax-meminst>`, :ref:`tags <syntax-taginst>`, and :ref:`globals <syntax-globalinst>` are *allocated* in a :ref:`store <syntax-store>` :math:`S`, as defined by the following auxiliary functions.
 
 
 .. index:: function, function instance, function address, module instance, function type
@@ -316,29 +297,29 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
    \end{array}
 
 
-.. index:: exception, exception instance, exception address, exception type
-.. _alloc-exn:
+.. index:: tag, tag instance, tag address, tag type
+.. _alloc-tag:
 
-:ref:`Exceptions <syntax-exninst>`
-..................................
+:ref:`Tags <syntax-taginst>`
+............................
 
-1. Let :math:`\exntype` be the :ref:`exception type <syntax-exntype>` to allocate.
+1. Let :math:`\tagtype` be the :ref:`tag type <syntax-tagtype>` to allocate.
 
-2. Let :math:`a` be the first free :ref:`exception address <syntax-exnaddr>` in :math:`S`.
+2. Let :math:`a` be the first free :ref:`tag address <syntax-tagaddr>` in :math:`S`.
 
-3. Let :math:`\exninst` be the :ref:`exception instance <syntax-exninst>` :math:`\{ \EITYPE~\exntype \}`.
+3. Let :math:`\taginst` be the :ref:`tag instance <syntax-taginst>` :math:`\{ \TAGITYPE~\tagtype \}`.
 
-4. Append :math:`\exninst` to the |SEXNS| of :math:`S`.
+4. Append :math:`\taginst` to the |STAGS| of :math:`S`.
 
 5. Return :math:`a`.
 
 .. math::
    \begin{array}{rlll}
-   \allocexn(S, \exntype) &=& S', \exnaddr \\[1ex]
+   \alloctag(S, \tagtype) &=& S', \tagaddr \\[1ex]
    \mbox{where:} \hfill \\
-   \exnaddr &=& |S.\SEXNS| \\
-   \exninst &=& \{ \EITYPE~\exntype \} \\
-   S' &=& S \compose \{\SEXNS~\exninst\} \\
+   \tagaddr &=& |S.\STAGS| \\
+   \taginst &=& \{ \TAGITYPE~\tagtype \} \\
+   S' &=& S \compose \{\STAGS~\taginst\} \\
    \end{array}
 
 
@@ -494,7 +475,7 @@ Growing :ref:`memories <syntax-meminst>`
    \end{array}
 
 
-.. index:: module, module instance, function instance, table instance, memory instance, exception instance, global instance, export instance, function address, table address, memory address, exception address, global address, function index, table index, memory index, exception index, global index, type, function, table, memory, exception, global, import, export, external value, external type, matching
+.. index:: module, module instance, function instance, table instance, memory instance, tag instance, global instance, export instance, function address, table address, memory address, tag address, global address, function index, table index, memory index, tag index, global index, type, function, table, memory, tag, global, import, export, external value, external type, matching
 .. _alloc-module:
 
 :ref:`Modules <syntax-moduleinst>`
@@ -521,11 +502,11 @@ and list of :ref:`reference <syntax-ref>` vectors for the module's :ref:`element
 
    a. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` resulting from :ref:`allocating <alloc-mem>` :math:`\mem_i.\MTYPE`.
 
-5. For each :ref:`exception <syntax-exn>` :math:`\exn_i` in :math:`\module.\MEXNS`, do:
+5. For each :ref:`tag <syntax-tag>` :math:`\tag_i` in :math:`\module.\MTAGS`, do:
 
-   a. Let :math:`\exntype` be the :ref:`exception type <syntax-exntype>` :math:`\module.\MTYPES[\exn_i.ETYPE]`.
+   a. Let :math:`\tagtype` be the :ref:`tag type <syntax-tagtype>` :math:`\module.\MTYPES[\tag_i.\TAGTYPE]`.
 
-   b. Let :math:`\exnaddr_i` be the :ref:`exception address <syntax-exnaddr>` resulting from :ref:`allocating <alloc-exn>` :math:`\exntype`.
+   b. Let :math:`\tagaddr_i` be the :ref:`tag address <syntax-tagaddr>` resulting from :ref:`allocating <alloc-tag>` :math:`\tagtype`.
 
 6. For each :ref:`global <syntax-global>` :math:`\global_i` in :math:`\module.\MGLOBALS`, do:
 
@@ -545,7 +526,7 @@ and list of :ref:`reference <syntax-ref>` vectors for the module's :ref:`element
 
 11. Let :math:`\memaddr^\ast` be the concatenation of the :ref:`memory addresses <syntax-memaddr>` :math:`\memaddr_i` in index order.
 
-12. Let :math:`\exnaddr^\ast` be the concatenation of the :ref:`exception addresses <syntax-exnaddr>` :math:`\exnaddr_i` in index order.
+12. Let :math:`\tagaddr^\ast` be the concatenation of the :ref:`tag addresses <syntax-tagaddr>` :math:`\tagaddr_i` in index order.
 
 13. Let :math:`\globaladdr^\ast` be the concatenation of the :ref:`global addresses <syntax-globaladdr>` :math:`\globaladdr_i` in index order.
 
@@ -559,7 +540,7 @@ and list of :ref:`reference <syntax-ref>` vectors for the module's :ref:`element
 
 18. Let :math:`\memaddr_{\F{mod}}^\ast` be the list of :ref:`memory addresses <syntax-memaddr>` extracted from :math:`\externval_{\F{im}}^\ast`, concatenated with :math:`\memaddr^\ast`.
 
-19. Let :math:`\exnaddr_{\F{mod}}^\ast` be the list of :ref:`exception addresses <syntax-exnaddr>` extracted from :math:`\externval_{\F{im}}^\ast`, concatenated with :math:`\exnaddr^\ast`.
+19. Let :math:`\tagaddr_{\F{mod}}^\ast` be the list of :ref:`tag addresses <syntax-tagaddr>` extracted from :math:`\externval_{\F{im}}^\ast`, concatenated with :math:`\tagaddr^\ast`.
 
 20. Let :math:`\globaladdr_{\F{mod}}^\ast` be the list of :ref:`global addresses <syntax-globaladdr>` extracted from :math:`\externval_{\F{im}}^\ast`, concatenated with :math:`\globaladdr^\ast`.
 
@@ -571,7 +552,7 @@ and list of :ref:`reference <syntax-ref>` vectors for the module's :ref:`element
 
     c. Else, if :math:`\export_i` is a memory export for :ref:`memory index <syntax-memidx>` :math:`x`, then let :math:`\externval_i` be the :ref:`external value <syntax-externval>` :math:`\EVMEM~(\memaddr_{\F{mod}}^\ast[x])`.
 
-    d. Else, if :math:`\export_i` is an exception export for :ref:`exception index <syntax-exnidx>` :math:`x`, then let :math:`\externval_i` be the :ref:`external value <syntax-externval>` :math:`\EVEXN~(\exnaddr_{\F{mod}}^\ast[x])`.
+    d. Else, if :math:`\export_i` is a tag export for :ref:`tag index <syntax-tagidx>` :math:`x`, then let :math:`\externval_i` be the :ref:`external value <syntax-externval>` :math:`\EVTAG~(\tagaddr_{\F{mod}}^\ast[x])`.
 
     e. Else, if :math:`\export_i` is a global export for :ref:`global index <syntax-globalidx>` :math:`x`, then let :math:`\externval_i` be the :ref:`external value <syntax-externval>` :math:`\EVGLOBAL~(\globaladdr_{\F{mod}}^\ast[x])`.
 
@@ -579,7 +560,7 @@ and list of :ref:`reference <syntax-ref>` vectors for the module's :ref:`element
 
 22. Let :math:`\exportinst^\ast` be the concatenation of the :ref:`export instances <syntax-exportinst>` :math:`\exportinst_i` in index order.
 
-23. Let :math:`\moduleinst` be the :ref:`module instance <syntax-moduleinst>` :math:`\{\MITYPES~(\module.\MTYPES),` :math:`\MIFUNCS~\funcaddr_{\F{mod}}^\ast,` :math:`\MITABLES~\tableaddr_{\F{mod}}^\ast,` :math:`\MIMEMS~\memaddr_{\F{mod}}^\ast,` :math:`\MIEXNS~\exnaddr_{\F{mod}}^\ast`, :math:`\MIGLOBALS~\globaladdr_{\F{mod}}^\ast,` :math:`\MIEXPORTS~\exportinst^\ast\}`.
+23. Let :math:`\moduleinst` be the :ref:`module instance <syntax-moduleinst>` :math:`\{\MITYPES~(\module.\MTYPES),` :math:`\MIFUNCS~\funcaddr_{\F{mod}}^\ast,` :math:`\MITABLES~\tableaddr_{\F{mod}}^\ast,` :math:`\MIMEMS~\memaddr_{\F{mod}}^\ast,` :math:`\MITAGS~\tagaddr_{\F{mod}}^\ast`, :math:`\MIGLOBALS~\globaladdr_{\F{mod}}^\ast,` :math:`\MIEXPORTS~\exportinst^\ast\}`.
 
 24. Return :math:`\moduleinst`.
 
@@ -606,7 +587,7 @@ where:
      \MIFUNCS~\evfuncs(\externval_{\F{im}}^\ast)~\funcaddr^\ast, \\
      \MITABLES~\evtables(\externval_{\F{im}}^\ast)~\tableaddr^\ast, \\
      \MIMEMS~\evmems(\externval_{\F{im}}^\ast)~\memaddr^\ast, \\
-     \MIEXNS~\evexns(\externval_{\F{im}}^\ast)~\exnaddr^\ast, \\
+     \MITAGS~\evtags(\externval_{\F{im}}^\ast)~\tagaddr^\ast, \\
      \MIGLOBALS~\evglobals(\externval_{\F{im}}^\ast)~\globaladdr^\ast, \\
      \MIELEMS~\elemaddr^\ast, \\
      \MIDATAS~\dataaddr^\ast, \\
@@ -619,8 +600,8 @@ where:
      \quad (\where (\table.\TTYPE)^\ast = (\limits~t)^\ast) \\
    S_3, \memaddr^\ast &=&
      \allocmem^\ast(S_2, (\mem.\MTYPE)^\ast) \\
-   S_4, \exnaddr^\ast &=& \allocexn^\ast(S_3, \exn^\ast, \module)
-     \quad (\where \exn^\ast = \module.\MEXNS) \\
+   S_4, \tagaddr^\ast &=& \alloctag^\ast(S_3, \tag^\ast, \module)
+     \quad (\where \tag^\ast = \module.\MTAGS) \\
    S_5, \globaladdr^\ast &=&
      \allocglobal^\ast(S_4, (\global.\GTYPE)^\ast, \val^\ast) \\
    S_6, \elemaddr^\ast &=&
@@ -635,8 +616,8 @@ where:
      \qquad (\where x^\ast = \edtables(\export^\ast)) \\
    \evmems(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MIMEMS[x])^\ast
      \qquad (\where x^\ast = \edmems(\export^\ast)) \\
-   \evexns(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MIEXNS[x])^\ast
-     \qquad\!\!\! (\where x^\ast = \edexns(\export^\ast)) \\
+   \evtags(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MITAGS[x])^\ast
+     \qquad\!\!\! (\where x^\ast = \edtags(\export^\ast)) \\
    \evglobals(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MIGLOBALS[x])^\ast
      \qquad\!\!\! (\where x^\ast = \edglobals(\export^\ast)) \\
    \end{array}

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -83,7 +83,7 @@ The following auxiliary typing rules specify this typing relation relative to a 
 .. math::
    \frac{
    }{
-     S \vdashexternval \EVTAG~a : \ETTAG~(S.\STAGS[a].\TAGITYPE)
+     S \vdashexternval \EVTAG~a : \ETTAG~S.\STAGS[a].\TAGITYPE
    }
 
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -683,7 +683,7 @@ In order to be able to break jumping over exception handlers and caught exceptio
 
 .. math::
    \begin{array}{llll}
-   \production{(block contexts)} & \XC^{k} &::=& \handler~\XB^k~\END \\
+   \production{(control contexts)} & \XC^{k} &::=& \handler~\XB^k~\END \\
    & & | & \CAUGHTadm~\{\tagaddr~\val^\ast\}~\XB^k~\END \\
    \production{(block contexts)} & \XB^0 &::=& \dots ~|~  \val^\ast~\XC^0~\instr^\ast\\
    \production{(block contexts)} & \XB^{k+1} &::=& \dots ~|~ \val^\ast~\XC^{k+1}~\instr^\ast \\
@@ -726,7 +726,8 @@ Throw contexts allow matching the program context around a throw instruction up 
    Contrary to block contexts, throw contexts don't skip over handlers.
 
    Since handlers are not included above, there is always a unique maximal throw context to match the reduction rules.
-   This basically means that :math:`\CAUGHTadm {\dots} instr^\ast \END` is not a potential catching block for exceptions thrown by :math:`\instr^\ast`, since these are instructions in the scope of a |CATCH| or a |CATCHALL|.
+
+   CAUGHTadm blocks do not represent active handlers. Instead, they delimit the continuation of a handler that has already been selected. Their sole purpose is to record the exception that has been caught, such that |RETHROW| can access it inside such a block.
 
 .. note::
    For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -727,7 +727,7 @@ Throw contexts allow matching the program context around a throw instruction up 
 
    Since handlers are not included above, there is always a unique maximal throw context to match the reduction rules.
 
-   CAUGHTadm blocks do not represent active handlers. Instead, they delimit the continuation of a handler that has already been selected. Their sole purpose is to record the exception that has been caught, such that |RETHROW| can access it inside such a block.
+   |CAUGHTadm| blocks do not represent active handlers. Instead, they delimit the continuation of a handler that has already been selected. Their sole purpose is to record the exception that has been caught, such that |RETHROW| can access it inside such a block.
 
 .. note::
    For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.
@@ -751,10 +751,12 @@ Throw contexts allow matching the program context around a throw instruction up 
       \stepto & \val^m & \\
       \end{array}
 
-   When a throw occurs, we pop the values :math:`val^m:[t^m]` and append them to the tag address :math:`a` into
-   a |CAUGHTadm| instruction. We then search for the maximal surrounding throw context `T`, which means we pop
-   any other values, labels, frames, and |CAUGHTadm| instructions, until we find an exception handler
-   (corresponding to a try block) that :ref:`handles the exception <syntax-handler>`.
+
+
+   When a throw of the form :math:`val^m (throw a)` occurs, we search for the maximal surrounding throw context :math:`T`,
+   which means we pop any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`val^m (throw a)`,
+   until we find an exception handler (corresponding to a try block) that :ref:`handles the exception <syntax-handler>`.
+   We then append the values :math:`val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
 
    In other words, when a throw occurs, normal execution halts and exceptional execution begins, until the throw
    is the continuation (i.e., in the place of a :math:`\_`) of a throw context in a catching try block.

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -83,7 +83,8 @@ It is either a sequence of :ref:`values <syntax-val>` or a :ref:`trap <syntax-tr
      \TRAP
    \end{array}
 
-**TODO: add a result value for an unhandled exception** (e.g., |EXCEPTION|)
+.. todo::
+   Add a result value for an unhandled exception.
 
 .. note::
    In the current version of WebAssembly, a result can consist of at most one value.
@@ -543,18 +544,20 @@ to their associated branch *targets*, each of which is expressed syntactically a
 :ref:`instructions <syntax-instr>` possibly following a :ref:`tag address <syntax-tagaddr>`.
 If there is no :ref:`tag address <syntax-tagaddr>`, the instructions of that target correspond to a |CATCHALL| clause.
 
-**TODO: add prose** for delegating handlers.
+.. todo::
+   Add prose for delegating handlers.
 
 .. math::
    \begin{array}{llllll}
-     \production{(handler)} & \X{handler} &::=& \CATCHadm\{a^?~\instr^\ast\}^\ast &|& \DELEGATEadm\{l\}
+     \production{(handler)} & \handler &::=& \CATCHadm\{\tagaddr^?~\instr^\ast\}^\ast &|& \DELEGATEadm\{l\}
    \end{array}
 
-Intuitively, :math:`\CATCHadm\{a^?~\instr^\ast\}^\ast` maps exception tag addreses to possible *continuations* to execute
-when the handler catches a thrown exception.
+Intuitively, for each target :math:`\{\tagaddr^?~\instr^\ast\}` of a |CATCHadm|, :math:`\instr^\ast` is the *continuation* to execute
+when the handler catches a thrown exception with tag |tagaddr|, or for any exception, when a target specifies no tag address.
 If this list of targets is empty, or if the tag address of the thrown exception is not in the handler's mapping and there is no |CATCHALL| clause, then the exception will be rethrown.
 
-**TODO: add prose** with intuition on delegating handlers.
+.. todo::
+   Add prose with intuition on delegating handlers.
 
 
 .. _exec-expand:
@@ -722,7 +725,7 @@ Throw contexts allow matching the program context around a throw instruction up 
    Contrary to block contexts, throw contexts don't skip over handlers.
 
    Since handlers are not included above, there is always a unique maximal throw context to match the reduction rules.
-   This basically means that :math:`\CAUGHTadm {..} instr^\ast \END` is not a potential catching block for exceptions thrown by :math:`\instr^\ast`, since it is inside a |handler|'s block.
+   This basically means that :math:`\CAUGHTadm {\dots} instr^\ast \END` is not a potential catching block for exceptions thrown by :math:`\instr^\ast`, since these are instructions in the scope of a |CATCH| or a |CATCHALL|.
 
 .. note::
    For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.
@@ -746,7 +749,11 @@ Throw contexts allow matching the program context around a throw instruction up 
 
    In this particular case, the exception is caught by the exception handler :math:`H` and its values are returned.
 
-   **TODO: add administrative values to describe unresolved throws:** e.g., |EXCEPTION|
+.. todo::
+   Include a more complex example using a throw context other then `T=[\_]`
+
+.. todo::
+   Add administrative values to describe unresolved throws.
 
 
 .. index:: ! configuration, ! thread, store, frame, instruction, module instruction
@@ -804,7 +811,8 @@ Finally, the following definition of *evaluation context* and associated structu
 Reduction terminates when a thread's instruction sequence has been reduced to a :ref:`result <syntax-result>`,
 that is, either a sequence of :ref:`values <syntax-val>` or to a |TRAP|.
 
-**TODO: add rules to deal with unresolved** :math:`\THROWadm~\tagaddr`, **and extend results to include such situations.** (e.g., |EXCEPTION|)
+.. todo::
+   Add rules to deal with unresolved :math:`\THROWadm~\tagaddr`, and extend results to include such situations.
 
 .. note::
    The restriction on evaluation contexts rules out contexts like :math:`[\_]` and :math:`\epsilon~[\_]~\epsilon` for which :math:`E[\TRAP] = \TRAP`.

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -741,7 +741,7 @@ Throw contexts allow matching the program context around a throw instruction up 
       \stepto & S;~F;~\LABEL_m\{\} (\CATCHadm\{a~\RETURN\}~\val^n~(\THROW~x)~\END)~\END \\
       \end{array}
 
-   Denote :math:`\val^n = \val^{n-m} \val^m`.
+   We denote :math:`\val^n = \val^{n-m} \val^m`.
    :ref:`Handling the thrown exception <exec-throwadm>` with tag address :math:`a` in the throw context
    :math:`T=[val^{n-m}\_]`, with the exception handler :math:`H=\CATCHadm\{a~\RETURN\}` gives:
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -7,7 +7,7 @@ Runtime Structure
 :ref:`Store <store>`, :ref:`stack <stack>`, and other *runtime structure* forming the WebAssembly abstract machine, such as :ref:`values <syntax-val>` or :ref:`module instances <syntax-moduleinst>`, are made precise in terms of additional auxiliary syntax.
 
 
-.. index:: ! value, number, reference, constant, number type, vector type,  reference type, ! host address, ! exception address, value type, integer, floating-point, vector number, ! default value, embedder
+.. index:: ! value, number, reference, constant, number type, vector type,  reference type, ! host address, ! value type, integer, floating-point, vector number, ! default value, embedder
    pair: abstract syntax; value
 .. _syntax-num:
 .. _syntax-vecc:
@@ -26,7 +26,6 @@ It is convenient to reuse the same notation as for the |CONST| :ref:`instruction
 
 References other than null are represented with additional :ref:`administrative instructions <syntax-instr-admin>`.
 They either are *function references*, pointing to a specific :ref:`function address <syntax-funcaddr>`,
-*exception references* representing a caught exception pointing to a specific :ref:`exception address <syntax-exnaddr>` and carrying a sequence of :ref:`values <syntax-val>`,
 or *external references* pointing to an uninterpreted form of :ref:`extern address <syntax-externaddr>` that can be defined by the :ref:`embedder <embedder>` to represent its own objects.
 
 .. math::
@@ -41,8 +40,7 @@ or *external references* pointing to an uninterpreted form of :ref:`extern addre
    \production{(reference)} & \reff &::=&
      \REFNULL~t \\&&|&
      \REFFUNCADDR~\funcaddr \\&&|&
-     \REFEXTERNADDR~\externaddr \\&&|&
-     \REFEXNADDR~\exnaddr~\val^\ast \\
+     \REFEXTERNADDR~\externaddr \\
    \production{(value)} & \val &::=&
      \num ~|~ \vecc ~|~ \reff \\
    \end{array}
@@ -85,11 +83,13 @@ It is either a sequence of :ref:`values <syntax-val>` or a :ref:`trap <syntax-tr
      \TRAP
    \end{array}
 
+**TODO: add a result value for an unhandled exception** (e.g., |EXCEPTION|)
+
 .. note::
    In the current version of WebAssembly, a result can consist of at most one value.
 
 
-.. index:: ! store, function instance, table instance, memory instance, exception instance, global instance, module, allocation
+.. index:: ! store, function instance, table instance, memory instance, tag instance, global instance, module, allocation
    pair: abstract syntax; store
 .. _syntax-store:
 .. _store:
@@ -98,7 +98,7 @@ Store
 ~~~~~
 
 The *store* represents all global state that can be manipulated by WebAssembly programs.
-It consists of the runtime representation of all *instances* of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tableinst>`, :ref:`memories <syntax-meminst>`, :ref:`exceptions <syntax-exninst>`, and :ref:`globals <syntax-globalinst>`, :ref:`element segments <syntax-eleminst>`, and :ref:`data segments <syntax-datainst>` that have been :ref:`allocated <alloc>` during the life time of the abstract machine. [#gc]_
+It consists of the runtime representation of all *instances* of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tableinst>`, :ref:`memories <syntax-meminst>`, :ref:`tags <syntax-taginst>`, and :ref:`globals <syntax-globalinst>`, :ref:`element segments <syntax-eleminst>`, and :ref:`data segments <syntax-datainst>` that have been :ref:`allocated <alloc>` during the life time of the abstract machine. [#gc]_
 
 It is an invariant of the semantics that no element or data instance is :ref:`addressed <syntax-addr>` from anywhere else but the owning module instances.
 
@@ -111,7 +111,7 @@ Syntactically, the store is defined as a :ref:`record <notation-record>` listing
      \SFUNCS & \funcinst^\ast, \\
      \STABLES & \tableinst^\ast, \\
      \SMEMS & \meminst^\ast, \\
-     \SEXNS & \exninst^\ast, \\
+     \STAGS & \taginst^\ast, \\
      \SGLOBALS & \globalinst^\ast, \\
      \SELEMS & \eleminst^\ast, \\
      \SDATAS & \datainst^\ast ~\} \\
@@ -130,11 +130,11 @@ Convention
 * The meta variable :math:`S` ranges over stores where clear from context.
 
 
-.. index:: ! address, store, function instance, table instance, memory instance, exception instance, global instance, element instance, data instance, embedder
+.. index:: ! address, store, function instance, table instance, memory instance, tag instance, global instance, element instance, data instance, embedder
    pair: abstract syntax; function address
    pair: abstract syntax; table address
    pair: abstract syntax; memory address
-   pair: abstract syntax; exception address
+   pair: abstract syntax; tag address
    pair: abstract syntax; global address
    pair: abstract syntax; element address
    pair: abstract syntax; data address
@@ -142,7 +142,7 @@ Convention
    pair: function; address
    pair: table; address
    pair: memory; address
-   pair: exception; address
+   pair: tag; address
    pair: global; address
    pair: element; address
    pair: data; address
@@ -150,7 +150,7 @@ Convention
 .. _syntax-funcaddr:
 .. _syntax-tableaddr:
 .. _syntax-memaddr:
-.. _syntax-exnaddr:
+.. _syntax-tagaddr:
 .. _syntax-globaladdr:
 .. _syntax-elemaddr:
 .. _syntax-dataaddr:
@@ -160,7 +160,7 @@ Convention
 Addresses
 ~~~~~~~~~
 
-:ref:`Function instances <syntax-funcinst>`, :ref:`table instances <syntax-tableinst>`, :ref:`memory instances <syntax-meminst>`, :ref:`exception instances <syntax-exninst>`, :ref:`global instances <syntax-globalinst>`, :ref:`element instances <syntax-eleminst>`, and :ref:`data instances <syntax-datainst>` in the :ref:`store <syntax-store>` are referenced with abstract *addresses*.
+:ref:`Function instances <syntax-funcinst>`, :ref:`table instances <syntax-tableinst>`, :ref:`memory instances <syntax-meminst>`, :ref:`tag instances <syntax-taginst>`, :ref:`global instances <syntax-globalinst>`, :ref:`element instances <syntax-eleminst>`, and :ref:`data instances <syntax-datainst>` in the :ref:`store <syntax-store>` are referenced with abstract *addresses*.
 These are simply indices into the respective store component.
 In addition, an :ref:`embedder <embedder>` may supply an uninterpreted set of *host addresses*.
 
@@ -174,7 +174,7 @@ In addition, an :ref:`embedder <embedder>` may supply an uninterpreted set of *h
      \addr \\
    \production{(memory address)} & \memaddr &::=&
      \addr \\
-   \production{(exception address)} & \exnaddr &::=&
+   \production{(tag address)} & \tagaddr &::=&
      \addr \\
    \production{(global address)} & \globaladdr &::=&
      \addr \\
@@ -201,7 +201,7 @@ even where this identity is not observable from within WebAssembly code itself
    hence logical addresses can be arbitrarily large natural numbers.
 
 
-.. index:: ! instance, function type, function instance, table instance, memory instance, exception instance, global instance, element instance, data instance, export instance, table address, memory address, exception address, global address, element address, data address, index, name
+.. index:: ! instance, function type, function instance, table instance, memory instance, tag instance, global instance, element instance, data instance, export instance, table address, memory address, tag address, global address, element address, data address, index, name
    pair: abstract syntax; module instance
    pair: module; instance
 .. _syntax-moduleinst:
@@ -221,7 +221,7 @@ and collects runtime representations of all entities that are imported, defined,
      \MIFUNCS & \funcaddr^\ast, \\
      \MITABLES & \tableaddr^\ast, \\
      \MIMEMS & \memaddr^\ast, \\
-     \MIEXNS & \exnaddr^\ast, \\
+     \MITAGS & \tagaddr^\ast, \\
      \MIGLOBALS & \globaladdr^\ast, \\
      \MIELEMS & \elemaddr^\ast, \\
      \MIDATAS & \dataaddr^\ast, \\
@@ -230,7 +230,7 @@ and collects runtime representations of all entities that are imported, defined,
    \end{array}
 
 Each component references runtime instances corresponding to respective declarations from the original module -- whether imported or defined -- in the order of their static :ref:`indices <syntax-index>`.
-:ref:`Function instances <syntax-funcinst>`, :ref:`table instances <syntax-tableinst>`, :ref:`memory instances <syntax-meminst>`, :ref:`exception instances <syntax-exninst>`, and :ref:`global instances <syntax-globalinst>` are referenced with an indirection through their respective :ref:`addresses <syntax-addr>` in the :ref:`store <syntax-store>`.
+:ref:`Function instances <syntax-funcinst>`, :ref:`table instances <syntax-tableinst>`, :ref:`memory instances <syntax-meminst>`, :ref:`tag instances <syntax-taginst>`, and :ref:`global instances <syntax-globalinst>` are referenced with an indirection through their respective :ref:`addresses <syntax-addr>` in the :ref:`store <syntax-store>`.
 
 It is an invariant of the semantics that all :ref:`export instances <syntax-exportinst>` in a given module instance have different :ref:`names <syntax-name>`.
 
@@ -315,25 +315,22 @@ The bytes can be mutated through :ref:`memory instructions <syntax-instr-memory>
 It is an invariant of the semantics that the length of the byte vector, divided by page size, never exceeds the maximum size of :math:`\memtype`, if present.
 
 
-.. index:: ! exception instance, exception, exception tag, exception type
-   pair: abstract syntax; exception instance
-   pair: exception; instance
-.. _syntax-exninst:
+.. index:: ! tag instance, tag, exception tag, tag type
+   pair: abstract syntax; tag instance
+   pair: tag; instance
+.. _syntax-taginst:
 
-Exception Instances
-~~~~~~~~~~~~~~~~~~~
+Tag Instances
+~~~~~~~~~~~~~
 
-An *exception instance* is the runtime representation of an :ref:`exception <syntax-exn>` definition.
-It records the :ref:`type <syntax-exntype>` of the exception.
+A *tag instance* is the runtime representation of a :ref:`tag <syntax-tag>` definition.
+It records the :ref:`type <syntax-tagtype>` of the tag.
 
 .. math::
    \begin{array}{llll}
-   \production{(exception instance)} & \exninst &::=&
-     \{ \EITYPE~\exntype \} \\
+   \production{(tag instance)} & \taginst &::=&
+     \{ \TAGITYPE~\tagtype \} \\
    \end{array}
-
-.. note::
-   The :ref:`exception address <syntax-exnaddr>` of an exception instance is also called an *exception tag*.
 
 
 .. index:: ! global instance, global, value, mutability, instruction, embedder
@@ -412,7 +409,7 @@ It defines the export's :ref:`name <syntax-name>` and the associated :ref:`exter
    \end{array}
 
 
-.. index:: ! external value, function address, table address, memory address, exception address, global address, store, function, table, memory, exception, global
+.. index:: ! external value, function address, table address, memory address, tag address, global address, store, function, table, memory, tag, global
    pair: abstract syntax; external value
    pair: external; value
 .. _syntax-externval:
@@ -421,7 +418,7 @@ External Values
 ~~~~~~~~~~~~~~~
 
 An *external value* is the runtime representation of an entity that can be imported or exported.
-It is an :ref:`address <syntax-addr>` denoting either a :ref:`function instance <syntax-funcinst>`, :ref:`table instance <syntax-tableinst>`, :ref:`memory instance <syntax-meminst>`, :ref:`global instances <syntax-globalinst>`, or :ref:`exception instances <syntax-exninst>` in the shared :ref:`store <syntax-store>`.
+It is an :ref:`address <syntax-addr>` denoting either a :ref:`function instance <syntax-funcinst>`, :ref:`table instance <syntax-tableinst>`, :ref:`memory instance <syntax-meminst>`, :ref:`tag instances <syntax-taginst>`, or :ref:`global instances <syntax-globalinst>` in the shared :ref:`store <syntax-store>`.
 
 .. math::
    \begin{array}{llcl}
@@ -429,7 +426,7 @@ It is an :ref:`address <syntax-addr>` denoting either a :ref:`function instance 
      \EVFUNC~\funcaddr \\&&|&
      \EVTABLE~\tableaddr \\&&|&
      \EVMEM~\memaddr \\&&|&
-     \EVEXN~\exnaddr \\&&|&
+     \EVTAG~\tagaddr \\&&|&
      \EVGLOBAL~\globaladdr \\
    \end{array}
 
@@ -446,7 +443,7 @@ It filters out entries of a specific kind in an order-preserving fashion:
 
 * :math:`\evmems(\externval^\ast) = [\memaddr ~|~ (\EVMEM~\memaddr) \in \externval^\ast]`
 
-* :math:`\evexns(\externval^\ast) = [\exnaddr ~|~ (\EVEXN~\exnaddr) \in \externval^\ast]`
+* :math:`\evtags(\externval^\ast) = [\tagaddr ~|~ (\EVTAG~\tagaddr) \in \externval^\ast]`
 
 * :math:`\evglobals(\externval^\ast) = [\globaladdr ~|~ (\EVGLOBAL~\globaladdr) \in \externval^\ast]`
 
@@ -458,7 +455,6 @@ It filters out entries of a specific kind in an order-preserving fashion:
    pair: abstract syntax; handler
 .. _syntax-frame:
 .. _syntax-label:
-.. _syntax-catch:
 .. _frame:
 .. _label:
 .. _handler:
@@ -535,21 +531,31 @@ and a reference to the function's own :ref:`module instance <syntax-moduleinst>`
 
 The values of the locals are mutated by respective :ref:`variable instructions <syntax-instr-variable>`.
 
+.. _syntax-handler:
+
 Exception handlers
 ..................
 
-Like labels, exception handlers carry the return arity :math:`n` of the
-respective |TRY| block, and their associated branch *target*, which is
-expressed syntactically as an :ref:`instruction <syntax-instr>` sequence:
+Exception handlers are installed by |TRY| instructions and are either *catching handlers* or *delegating handlers*.
+
+Catching handlers start with the identifier |CATCHadm| and carry a mapping from :ref:`tag addresses <syntax-tagaddr>`
+to their associated branch *targets*, each of which is expressed syntactically as a possibly empty sequence of
+:ref:`instructions <syntax-instr>` possibly following a :ref:`tag address <syntax-tagaddr>`.
+If there is no :ref:`tag address <syntax-tagaddr>`, the instructions of that target correspond to a |CATCHALL| clause.
+
+**TODO: add prose** for delegating handlers.
 
 .. math::
-   \begin{array}{llll}
-   \production{(handler)} & \X{handler} &::=&
-     \CATCH_n\{\instr^\ast\}\\
+   \begin{array}{llllll}
+     \production{(handler)} & \X{handler} &::=& \CATCHadm\{a^?~\instr^\ast\}^\ast &|& \DELEGATEadm\{l\}
    \end{array}
 
-Intuitively, :math:`\instr^\ast` is the *continuation* to execute
+Intuitively, :math:`\CATCHadm\{a^?~\instr^\ast\}^\ast` maps exception tag addreses to possible *continuations* to execute
 when the handler catches a thrown exception.
+If this list of targets is empty, or if the tag address of the thrown exception is not in the handler's mapping and there is no |CATCHALL| clause, then the exception will be rethrown.
+
+**TODO: add prose** with intuition on delegating handlers.
+
 
 .. _exec-expand:
 
@@ -560,6 +566,8 @@ Conventions
 
 * The meta variable :math:`F` ranges over frames where clear from context.
 
+* The meta variable :math:`H` ranges over exception handlers where clear from context.
+
 * The following auxiliary definition takes a :ref:`block type <syntax-blocktype>` and looks up the :ref:`function type <syntax-functype>` that it denotes in the current frame:
 
 .. math::
@@ -569,14 +577,15 @@ Conventions
    \end{array}
 
 
-.. index:: ! administrative instructions, function, function instance, function address, label, frame, instruction, trap, call, memory, memory instance, table, table instance, element, data, segment, exception, exception instance, exception address, exception, reftype
+.. index:: ! administrative instructions, function, function instance, function address, label, frame, instruction, trap, call, memory, memory instance, table, table instance, element, data, segment, tag, tag instance, tag address, exceptions, reftype, catch, delegate, handler, caught
    pair:: abstract syntax; administrative instruction
 .. _syntax-trap:
 .. _syntax-reffuncaddr:
 .. _syntax-invoke:
-.. _syntax-refexnaddr:
-.. _syntax-throwaddr:
-.. _syntax-catchn:
+.. _syntax-throwadm:
+.. _syntax-catchadm:
+.. _syntax-delegateadm:
+.. _syntax-caughtadm:
 .. _syntax-instr-admin:
 
 Administrative Instructions
@@ -585,7 +594,7 @@ Administrative Instructions
 .. note::
    This section is only relevant for the :ref:`formal notation <exec-notation>`.
 
-In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-call>`, :ref:`exception handling <exec-catch>`, and :ref:`control instructions <syntax-instr-control>`, the syntax of instructions is extended to include the following *administrative instructions*:
+In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-call>`, :ref:`exception handling <exec-throwadm>`, and :ref:`control instructions <syntax-instr-control>`, the syntax of instructions is extended to include the following *administrative instructions*:
 
 .. math::
    \begin{array}{llcl}
@@ -595,27 +604,27 @@ In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-ca
      \REFFUNCADDR~\funcaddr \\ &&|&
      \REFEXTERNADDR~\externaddr \\ &&|&
      \INVOKE~\funcaddr \\ &&|&
-     \REFEXNADDR~\exnaddr~\val^\ast \\ &&|&
-     \THROWADDR~\exnaddr \\ &&|&
+     \THROWadm~\tagaddr \\ &&|&
      \LABEL_n\{\instr^\ast\}~\instr^\ast~\END \\ &&|&
-     \CATCHN_n\{\instr^\ast\}~\instr^\ast~\END \\ &&|&
+     \CATCHadm\{a^?~\instr^\ast\}^\ast~\instr^\ast~\END \\ &&|&
+     \DELEGATEadm\{l\}~\instr^\ast~\END \\ &&|&
+     \CAUGHTadm\{a~\val^\ast\}~\instr^\ast~\END \\ &&|&
      \FRAME_n\{\frame\}~\instr^\ast~\END \\
    \end{array}
 
 The |TRAP| instruction represents the occurrence of a trap.
 Traps are bubbled up through nested instruction sequences, ultimately reducing the entire program to a single |TRAP| instruction, signalling abrupt termination.
 
-The |REFFUNCADDR| instruction represents :ref:`function reference values <syntax-ref.func>`. Similarly, |REFEXTERNADDR| represents :ref:`external references <syntax-ref.extern>`,
-and |REFEXNADDR| represents :ref:`exception reference values <syntax-refexnaddr>` of caught exceptions.
+The |REFFUNCADDR| instruction represents :ref:`function reference values <syntax-ref.func>`. Similarly, |REFEXTERNADDR| represents :ref:`external references <syntax-ref.extern>`.
 
 The |INVOKE| instruction represents the imminent invocation of a :ref:`function instance <syntax-funcinst>`, identified by its :ref:`address <syntax-funcaddr>`.
 It unifies the handling of different forms of calls.
 
-The |THROWADDR| instruction represents the imminent throw of an :ref:`exception reference value <syntax-refexnaddr>` based on an :ref:`exception instance <syntax-exninst>`, identified by its :ref:`address <syntax-exnaddr>`.
-The values it will consume to create the exception depend on its :ref:`exception type <syntax-exntype>`.
+The |THROWadm| instruction represents the imminent throw of an exception based on a :ref:`tag instance <syntax-taginst>`, identified by its :ref:`address <syntax-tagaddr>`.
+The values it will consume depend on its :ref:`tag type <syntax-tagtype>`.
 It unifies the throwing of different forms of exceptions.
 
-The |LABEL|, |FRAME|, and |CATCHN| instructions model :ref:`labels <syntax-label>`, :ref:`frames <syntax-frame>`, and active :ref:`exception handlers <syntax-try>`, respectively, :ref:`"on the stack" <exec-notation>`.
+The |LABEL|, |FRAME|, |CATCHadm|, |DELEGATEadm|, and |CAUGHTadm| instructions model :ref:`labels <syntax-label>`, :ref:`frames <syntax-frame>`, active :ref:`catching exception handlers <syntax-try-catch>`, active :ref:`delegating exception handlers <syntax-try-delegate>`, and :ref:`caught exceptions <exec-throwadm>`, respectively, :ref:`"on the stack" <exec-notation>`.
 Moreover, the administrative syntax maintains the nesting structure of the original :ref:`structured control instruction <syntax-instr-control>` or :ref:`function body <syntax-func>` and their :ref:`instruction sequences <syntax-instr-seq>` with an |END| marker.
 That way, the end of the inner instruction sequence is known when part of an outer sequence.
 
@@ -666,6 +675,16 @@ In order to specify the reduction of :ref:`branches <syntax-instr-control>`, the
 
 This definition allows to index active labels surrounding a :ref:`branch <syntax-br>` or :ref:`return <syntax-return>` instruction.
 
+In order to be able to break jumping over exception handlers and caught exceptions, we must allow for these new structured administrative control instructions to appear after labels in block contexts, by extending block context as follows.
+
+.. math::
+   \begin{array}{llll}
+   \production{(block contexts)} & \XC^{k} &::=& \handler~\XB^k~\END \\
+   & & | & \CAUGHTadm~\{\tagaddr~\val^\ast\}~\XB^k~\END \\
+   \production{(block contexts)} & \XB^0 &::=& \dots ~|~  \val^\ast~\XC^0~\instr^\ast\\
+   \production{(block contexts)} & \XB^{k+1} &::=& \dots ~|~ \val^\ast~\XC^{k+1}~\instr^\ast \\
+   \end{array}
+
 .. note::
    For example, the :ref:`reduction <exec-br>` of a simple branch can be defined as follows:
 
@@ -678,14 +697,14 @@ This definition allows to index active labels surrounding a :ref:`branch <syntax
    The selected label is identified through the :ref:`label index <syntax-labelidx>` :math:`l`, which corresponds to the number of surrounding |LABEL| instructions that must be hopped over -- which is exactly the count encoded in the index of a block context.
 
 
-.. index:: ! throw context, exception, throw address, catch block
+.. index:: ! throw context, tag, throw address, catch block, handler, exception
 .. _syntax-ctxt-throw:
 
 Throw Contexts
 ..............
 
 In order to specify the reduction of |TRY| blocks
-with the help of the administrative instructions |THROWADDR|, |REFEXNADDR|, and |CATCHN|,
+with the help of the administrative instructions |THROWadm|, |CATCHadm|, |DELEGATEadm|, and |CAUGHTadm|,
 the following syntax of *throw contexts* is defined, as well as associated structural rules:
 
 .. math::
@@ -693,36 +712,41 @@ the following syntax of *throw contexts* is defined, as well as associated struc
    \production{(throw contexts)} & \XT &::=&
      \val^\ast~[\_]~\instr^\ast \\ &&|&
      \LABEL_n\{\instr^\ast\}~\XT~\END \\ &&|&
-     \CATCHN_n\{\instr^\ast\}~\XT~\END \\ &&|&
+     \CAUGHTadm\{a~\val^\ast\}~\XT~\END \\ &&|&
      \FRAME_n\{F\}~\XT~\END \\
    \end{array}
 
-Throw contexts allow matching the program context around a throw instruction up to the nearest enclosing :math:`\CATCHN` handler, thereby selecting the exception handler responsible for an exception.
+Throw contexts allow matching the program context around a throw instruction up to the innermost enclosing |CATCHadm| or |DELEGATEadm|, thereby selecting the exception |handler| responsible for an exception, if one exists.
 
 .. note::
-   For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try>` would be as follows.
+   Contrary to block contexts, throw contexts don't skip over handlers.
+
+   Since handlers are not included above, there is always a unique maximal throw context to match the reduction rules.
+   This basically means that :math:`\CAUGHTadm {..} instr^\ast \END` is not a potential catching block for exceptions thrown by :math:`\instr^\ast`, since it is inside a |handler|'s block.
+
+.. note::
+   For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.
 
    .. math::
       \begin{array}{ll}
-      & \hspace{-5ex} S;~F;~\val^n~(\TRY~\X{bt}~\THROW~x~\CATCH~\RETURN~\END) \\
-      \stepto & S;~F;~\CATCHN_1\{\RETURN\}~(\LABEL_1 \{\}~\val^n~\THROWADDR~a~\END)~\END \\
+      & \hspace{-5ex} S;~F;~\val^n~(\TRY~\X{bt}~\THROW~x~\CATCH~x~\RETURN~\END) \\
+      \stepto & S;~F;~\LABEL_n\{\} (\CATCHadm\{a~\RETURN\}~~\val^n~\THROWadm~a~\END)~\END \\
       \end{array}
 
-   :ref:`Handling <exec-throwaddr>` the thrown exception address :math:`a` in the throw context
-   :math:`T=\LABEL_1 \{\}[\_]~\END`, with the exception handler :math:`\CATCHN_1\{\RETURN\}` gives:
+   :ref:`Handling <exec-throwadm>` the thrown exception with tag address :math:`a` in the throw context
+   :math:`T=[\_]`, with the exception handler :math:`H=\CATCHadm\{a~\RETURN\}` gives:
 
    .. math::
       \begin{array}{lll}
-      \stepto & S;~F;~\LABEL_1~\{\}~(\REFEXNADDR~a~\val^n)~\RETURN~\END & \hspace{9ex}\ \\
-      \stepto & (\REFEXNADDR~a~\val^n) & \\
+      \stepto & S;~F;~\LABEL_n\{\}~(\CAUGHTadm\{a~\val^n\}~\val^n~\RETURN~\END)~\END & \hspace{9ex}\ \\
+      \stepto & \val^n & \\
       \end{array}
 
    When a throw occurs, execution halts until that throw is the continuation of a throw context in a catching try block.
 
-   In this particular case, the exception reference is returned normally, as opposed to being thrown as the result of a plain
-   :math:`\THROW~x` without a catching |TRY| block.
+   In this particular case, the exception is caught by the exception handler :math:`H` and its values are returned.
 
-   *(TODO: add administrative values to describe unresolved throws).*
+   **TODO: add administrative values to describe unresolved throws:** e.g., |EXCEPTION|
 
 
 .. index:: ! configuration, ! thread, store, frame, instruction, module instruction
@@ -780,7 +804,7 @@ Finally, the following definition of *evaluation context* and associated structu
 Reduction terminates when a thread's instruction sequence has been reduced to a :ref:`result <syntax-result>`,
 that is, either a sequence of :ref:`values <syntax-val>` or to a |TRAP|.
 
-*(TODO: add rules to deal with unresolved* :math:`\THROWADDR~\exnaddr`, *and extend results to include such situations.)*
+**TODO: add rules to deal with unresolved** :math:`\THROWadm~\tagaddr`, **and extend results to include such situations.** (e.g., |EXCEPTION|)
 
 .. note::
    The restriction on evaluation contexts rules out contexts like :math:`[\_]` and :math:`\epsilon~[\_]~\epsilon` for which :math:`E[\TRAP] = \TRAP`.

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -594,7 +594,7 @@ Administrative Instructions
 .. note::
    This section is only relevant for the :ref:`formal notation <exec-notation>`.
 
-In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-call>`, :ref:`exception handling <exec-throwadm>`, and :ref:`control instructions <syntax-instr-control>`, the syntax of instructions is extended to include the following *administrative instructions*:
+In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-call>`, :ref:`exception handling <syntax-handler>`, and :ref:`control instructions <syntax-instr-control>`, the syntax of instructions is extended to include the following *administrative instructions*:
 
 .. math::
    \begin{array}{llcl}
@@ -606,9 +606,9 @@ In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-ca
      \INVOKE~\funcaddr \\ &&|&
      \THROWadm~\tagaddr \\ &&|&
      \LABEL_n\{\instr^\ast\}~\instr^\ast~\END \\ &&|&
-     \CATCHadm\{a^?~\instr^\ast\}^\ast~\instr^\ast~\END \\ &&|&
+     \CATCHadm\{\tagaddr^?~\instr^\ast\}^\ast~\instr^\ast~\END \\ &&|&
      \DELEGATEadm\{l\}~\instr^\ast~\END \\ &&|&
-     \CAUGHTadm\{a~\val^\ast\}~\instr^\ast~\END \\ &&|&
+     \CAUGHTadm\{\tagaddr~\val^\ast\}~\instr^\ast~\END \\ &&|&
      \FRAME_n\{\frame\}~\instr^\ast~\END \\
    \end{array}
 
@@ -622,7 +622,7 @@ It unifies the handling of different forms of calls.
 
 The |THROWadm| instruction represents the imminent throw of an exception based on a :ref:`tag instance <syntax-taginst>`, identified by its :ref:`address <syntax-tagaddr>`.
 The values it will consume depend on its :ref:`tag type <syntax-tagtype>`.
-It unifies the throwing of different forms of exceptions.
+It unifies the different forms of throwing exceptions.
 
 The |LABEL|, |FRAME|, |CATCHadm|, |DELEGATEadm|, and |CAUGHTadm| instructions model :ref:`labels <syntax-label>`, :ref:`frames <syntax-frame>`, active :ref:`catching exception handlers <syntax-try-catch>`, active :ref:`delegating exception handlers <syntax-try-delegate>`, and :ref:`caught exceptions <exec-throwadm>`, respectively, :ref:`"on the stack" <exec-notation>`.
 Moreover, the administrative syntax maintains the nesting structure of the original :ref:`structured control instruction <syntax-instr-control>` or :ref:`function body <syntax-func>` and their :ref:`instruction sequences <syntax-instr-seq>` with an |END| marker.
@@ -712,7 +712,7 @@ the following syntax of *throw contexts* is defined, as well as associated struc
    \production{(throw contexts)} & \XT &::=&
      \val^\ast~[\_]~\instr^\ast \\ &&|&
      \LABEL_n\{\instr^\ast\}~\XT~\END \\ &&|&
-     \CAUGHTadm\{a~\val^\ast\}~\XT~\END \\ &&|&
+     \CAUGHTadm\{\tagaddr~\val^\ast\}~\XT~\END \\ &&|&
      \FRAME_n\{F\}~\XT~\END \\
    \end{array}
 
@@ -733,7 +733,7 @@ Throw contexts allow matching the program context around a throw instruction up 
       \stepto & S;~F;~\LABEL_n\{\} (\CATCHadm\{a~\RETURN\}~~\val^n~\THROWadm~a~\END)~\END \\
       \end{array}
 
-   :ref:`Handling <exec-throwadm>` the thrown exception with tag address :math:`a` in the throw context
+   :ref:`Handling <syntax-handler>` the thrown exception with tag address :math:`a` in the throw context
    :math:`T=[\_]`, with the exception handler :math:`H=\CATCHadm\{a~\RETURN\}` gives:
 
    .. math::

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -741,7 +741,7 @@ Throw contexts allow matching the program context around a throw instruction up 
       \stepto & S;~F;~\LABEL_m\{\} (\CATCHadm\{a~\RETURN\}~\val^n~(\THROW~x)~\END)~\END \\
       \end{array}
 
-   Denote :math:`\val^n = \val^{n-m} val^m`.
+   Denote :math:`\val^n = \val^{n-m} \val^m`.
    :ref:`Handling the thrown exception <exec-throwadm>` with tag address :math:`a` in the throw context
    :math:`T=[val^{n-m}\_]`, with the exception handler :math:`H=\CATCHadm\{a~\RETURN\}` gives:
 
@@ -753,8 +753,8 @@ Throw contexts allow matching the program context around a throw instruction up 
 
 
 
-   When a throw of the form :math:`val^m (throw a)` occurs, we search for the maximal surrounding throw context :math:`T`,
-   which means we pop any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`val^m (throw a)`,
+   When a throw of the form :math:`val^m (\THROWadm~a)` occurs, we search for the maximal surrounding throw context :math:`T`,
+   which means we pop any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`val^m (\THROWadm~a)`,
    until we find an exception handler (corresponding to a try block) that :ref:`handles the exception <syntax-handler>`.
    We then append the values :math:`val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -603,7 +603,7 @@ The |DATADROP| instruction prevents further use of a passive data segment. This 
    This restriction may be lifted in future versions.
 
 
-.. index:: ! control instruction, ! structured control, ! label, ! block, ! block type, ! branch, ! unwinding, result type, label index, function index, type index, exception index, vector, trap, function, table, exception, function type, value type, type index, exception index
+.. index:: ! control instruction, ! structured control, ! exception handling, ! label, ! block, ! block type, ! branch, result type, label index, function index, type index, tag index, vector, trap, function, table, tag, function type, value type, tag type, try block, catching try block
    pair: abstract syntax; instruction
    pair: abstract syntax; block type
    pair: block; type
@@ -614,9 +614,10 @@ The |DATADROP| instruction prevents further use of a passive data segment. This 
 .. _syntax-loop:
 .. _syntax-if:
 .. _syntax-try:
+.. _syntax-try-catch:
+.. _syntax-try-delegate:
 .. _syntax-throw:
 .. _syntax-rethrow:
-.. _syntax-br_on_exn:
 .. _syntax-br:
 .. _syntax-br_if:
 .. _syntax-br_table:
@@ -642,10 +643,10 @@ Instructions in this group affect the flow of control.
      \BLOCK~\blocktype~\instr^\ast~\END \\&&|&
      \LOOP~\blocktype~\instr^\ast~\END \\&&|&
      \IF~\blocktype~\instr^\ast~\ELSE~\instr^\ast~\END \\&&|&
-     \TRY~\blocktype~instr^\ast~\CATCH~\instr^\ast~\END \\&&|&
-     \THROW~\exnidx \\&&|&
-     \RETHROW \\&&|&
-     \BRONEXN~\labelidx~\exnidx \\&&|&
+     \TRY~\blocktype~instr^\ast~(\CATCH~\tagidx~\instr^\ast)^\ast~(\CATCHALL~\instr^\ast)^?~\END \\ &&|&
+     \TRY~\blocktype~instr^\ast~\DELEGATE~\labelidx \\ &&|&
+     \THROW~\tagidx \\&&|&
+     \RETHROW~\labelidx \\ &&|&
      \BR~\labelidx \\&&|&
      \BRIF~\labelidx \\&&|&
      \BRTABLE~\vec(\labelidx)~\labelidx \\&&|&
@@ -659,11 +660,15 @@ The |NOP| instruction does nothing.
 The |UNREACHABLE| instruction causes an unconditional :ref:`trap <trap>`.
 
 The |BLOCK|, |LOOP|, |IF|, and |TRY| instructions are *structured* instructions.
-They bracket nested sequences of instructions, called *blocks*, terminated with, or separated by, either |END|, |ELSE|, or |CATCH| pseudo-instructions.
+They bracket nested sequences of instructions, called *blocks*,
+separated by either |ELSE|, |CATCH|, or |CATCHALL| pseudo-instructions,
+and terminated with either an |END| or a |DELEGATE| pseudo-instruction.
 As the grammar prescribes, they must be well-nested.
 
-The instructions |TRY|, |THROW|, |RETHROW|, and |BRONEXN| are concerned with handling exceptions.
-The |THROW| and |RETHROW| instructions alter control flow by searching for the catching-try block, if any.
+The instructions |TRY|, |THROW|, and |RETHROW|, are concerned with handling exceptions.
+The |TRY| instructions create try-blocks, and either may handle or rethrow exceptions in the case of |CATCH| and |CATCHALL|,
+or delegate exceptions to an outer potentially catching try-block in the case of |DELEGATE|.
+The |THROW| and |RETHROW| instructions alter control flow by searching for a matching handler in an enclosing catching-try block, if any.
 
 A structured instruction can consume *input* and produce *output* on the operand stack according to its annotated *block type*.
 It is given either as a :ref:`type index <syntax-funcidx>` that refers to a suitable :ref:`function type <syntax-functype>`, or as an optional :ref:`value type <syntax-valtype>` inline, which is a shorthand for the function type :math:`[] \to [\valtype^?]`.
@@ -680,6 +685,7 @@ The exact effect depends on that control construct.
 In case of |BLOCK| or |IF| it is a *forward jump*,
 resuming execution after the matching |END|.
 In case of |LOOP| it is a *backward jump* to the beginning of the loop.
+**TODO: add prose** - for try-delegate's jump.
 
 .. note::
    This enforces *structured control flow*.
@@ -689,8 +695,8 @@ In case of |LOOP| it is a *backward jump* to the beginning of the loop.
 Branch instructions come in several flavors:
 |BR| performs an unconditional branch,
 |BRIF| performs a conditional branch,
-|BRONEXN| performs a branch if the exception on the stack matches the specified exception index,
 and |BRTABLE| performs an indirect branch through an operand indexing into the label vector that is an immediate to the instruction, or to a default target if the operand is out of bounds.
+
 The |RETURN| instruction is a shortcut for an unconditional branch to the outermost block, which implicitly is the body of the current function.
 Taking a branch *unwinds* the operand stack up to the height where the targeted structured control instruction was entered.
 However, branches may additionally consume operands themselves, which they push back on the operand stack after unwinding.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -685,7 +685,9 @@ The exact effect depends on that control construct.
 In case of |BLOCK| or |IF| it is a *forward jump*,
 resuming execution after the matching |END|.
 In case of |LOOP| it is a *backward jump* to the beginning of the loop.
-**TODO: add prose** - for try-delegate's jump.
+
+.. todo::
+   Add prose for try-delegate's jump.
 
 .. note::
    This enforces *structured control flow*.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -643,8 +643,8 @@ Instructions in this group affect the flow of control.
      \BLOCK~\blocktype~\instr^\ast~\END \\&&|&
      \LOOP~\blocktype~\instr^\ast~\END \\&&|&
      \IF~\blocktype~\instr^\ast~\ELSE~\instr^\ast~\END \\&&|&
-     \TRY~\blocktype~instr^\ast~(\CATCH~\tagidx~\instr^\ast)^\ast~(\CATCHALL~\instr^\ast)^?~\END \\ &&|&
-     \TRY~\blocktype~instr^\ast~\DELEGATE~\labelidx \\ &&|&
+     \TRY~\blocktype~\instr^\ast~(\CATCH~\tagidx~\instr^\ast)^\ast~(\CATCHALL~\instr^\ast)^?~\END \\ &&|&
+     \TRY~\blocktype~\instr^\ast~\DELEGATE~\labelidx \\ &&|&
      \THROW~\tagidx \\&&|&
      \RETHROW~\labelidx \\ &&|&
      \BR~\labelidx \\&&|&
@@ -666,9 +666,9 @@ and terminated with either an |END| or a |DELEGATE| pseudo-instruction.
 As the grammar prescribes, they must be well-nested.
 
 The instructions |TRY|, |THROW|, and |RETHROW|, are concerned with handling exceptions.
-The |TRY| instructions create try-blocks, and either may handle or rethrow exceptions in the case of |CATCH| and |CATCHALL|,
-or delegate exceptions to an outer potentially catching try-block in the case of |DELEGATE|.
-The |THROW| and |RETHROW| instructions alter control flow by searching for a matching handler in an enclosing catching-try block, if any.
+The |TRY| instruction installs an exception handler, and may either handle exceptions in the case of |CATCH| and |CATCHALL|,
+or rethrow them in an outer block in the case of |DELEGATE|.
+The |THROW| and |RETHROW| instructions alter control flow by searching for a matching handler in one of the enclosing |TRY| blocks, if any.
 
 A structured instruction can consume *input* and produce *output* on the operand stack according to its annotated *block type*.
 It is given either as a :ref:`type index <syntax-funcidx>` that refers to a suitable :ref:`function type <syntax-functype>`, or as an optional :ref:`value type <syntax-valtype>` inline, which is a shorthand for the function type :math:`[] \to [\valtype^?]`.

--- a/document/core/syntax/modules.rst
+++ b/document/core/syntax/modules.rst
@@ -1,4 +1,4 @@
-.. index:: ! module, type definition, function type, exception type, function, table, memory, exception, global, element, data, start function, import, export
+.. index:: ! module, type definition, function type, tag type, function, table, memory, tag, global, element, data, start function, import, export
    pair: abstract syntax; module
 .. _syntax-module:
 
@@ -7,7 +7,7 @@ Modules
 
 WebAssembly programs are organized into *modules*,
 which are the unit of deployment, loading, and compilation.
-A module collects definitions for :ref:`types <syntax-type>`, :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`exceptions <syntax-exn>`, and :ref:`globals <syntax-global>`.
+A module collects definitions for :ref:`types <syntax-type>`, :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`tags <syntax-tag>`, and :ref:`globals <syntax-global>`.
 In addition, it can declare :ref:`imports <syntax-import>` and :ref:`exports <syntax-export>`
 and provide initialization in the form of :ref:`data <syntax-data>` and :ref:`element <syntax-elem>` segments, or a :ref:`start function <syntax-start>`.
 
@@ -18,7 +18,7 @@ and provide initialization in the form of :ref:`data <syntax-data>` and :ref:`el
      \MFUNCS~\vec(\func), \\&&&&
      \MTABLES~\vec(\table), \\&&&&
      \MMEMS~\vec(\mem), \\&&&&
-     \MEXNS~\vec(\exn), \\&&&&
+     \MTAGS~\vec(\tag), \\&&&&
      \MGLOBALS~\vec(\global), \\&&&&
      \MELEMS~\vec(\elem), \\&&&&
      \MDATAS~\vec(\data), \\&&&&
@@ -30,12 +30,12 @@ and provide initialization in the form of :ref:`data <syntax-data>` and :ref:`el
 Each of the vectors -- and thus the entire module -- may be empty.
 
 
-.. index:: ! index, ! index space, ! type index, ! function index, ! table index, ! memory index, ! exception index, ! global index, ! local index, ! label index, ! element index, ! data index, function, global, table, memory, exception, element, data, local, parameter, import
+.. index:: ! index, ! index space, ! type index, ! function index, ! table index, ! memory index, ! tag index, ! global index, ! local index, ! label index, ! element index, ! data index, function, global, table, memory, tag, element, data, local, parameter, import
    pair: abstract syntax; type index
    pair: abstract syntax; function index
    pair: abstract syntax; table index
    pair: abstract syntax; memory index
-   pair: abstract syntax; exception index
+   pair: abstract syntax; tag index
    pair: abstract syntax; global index
    pair: abstract syntax; element index
    pair: abstract syntax; data index
@@ -45,7 +45,7 @@ Each of the vectors -- and thus the entire module -- may be empty.
    pair: function; index
    pair: table; index
    pair: memory; index
-   pair: exception; index
+   pair: tag; index
    pair: global; index
    pair: element; index
    pair: data; index
@@ -55,7 +55,7 @@ Each of the vectors -- and thus the entire module -- may be empty.
 .. _syntax-funcidx:
 .. _syntax-tableidx:
 .. _syntax-memidx:
-.. _syntax-exnidx:
+.. _syntax-tagidx:
 .. _syntax-globalidx:
 .. _syntax-elemidx:
 .. _syntax-dataidx:
@@ -75,7 +75,7 @@ Each class of definition has its own *index space*, as distinguished by the foll
    \production{function index} & \funcidx &::=& \u32 \\
    \production{table index} & \tableidx &::=& \u32 \\
    \production{memory index} & \memidx &::=& \u32 \\
-   \production{exception index} & \exnidx &::=& \u32 \\
+   \production{tag index} & \tagidx &::=& \u32 \\
    \production{global index} & \globalidx &::=& \u32 \\
    \production{element index} & \elemidx &::=& \u32 \\
    \production{data index} & \dataidx &::=& \u32 \\
@@ -83,7 +83,7 @@ Each class of definition has its own *index space*, as distinguished by the foll
    \production{label index} & \labelidx &::=& \u32 \\
    \end{array}
 
-The index space for :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`exceptions <syntax-exn>`, and :ref:`globals <syntax-global>` includes respective :ref:`imports <syntax-import>` declared in the same module.
+The index space for :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`tags <syntax-tag>`, and :ref:`globals <syntax-global>` includes respective :ref:`imports <syntax-import>` declared in the same module.
 The indices of these imports precede the indices of other definitions in the same index space.
 
 Element indices reference :ref:`element segments <syntax-elem>` and data indices reference :ref:`data segments <syntax-data>`.
@@ -97,7 +97,7 @@ Label indices reference :ref:`structured control instructions <syntax-instr-cont
 .. _free-funcidx:
 .. _free-tableidx:
 .. _free-memidx:
-.. _free-exnidx:
+.. _free-tagidx:
 .. _free-globalidx:
 .. _free-elemidx:
 .. _free-dataidx:
@@ -220,24 +220,24 @@ Most constructs implicitly reference memory index :math:`0`.
 
 
 
-.. index:: ! exception, table index, function index, exception type
-   pair: abstract syntax; exception
-.. _syntax-exn:
+.. index:: ! tag, function index, tag type
+   pair: abstract syntax; tag
+.. _syntax-tag:
 
-Exceptions
-~~~~~~~~~~
+Tags
+~~~~
 
-The |MEXNS| component of a module defines a vector of *exceptions* with the following structure.
+The |MTAGS| component of a module defines a vector of *tags* with the following structure.
 
 .. math::
    \begin{array}{llll}
-   \production{exception} & \exn &::=& \{ \ETYPE~\typeidx \} \\
+   \production{tag} & \tag &::=& \{ \TAGTYPE~\typeidx \} \\
    \end{array}
 
 The result type of the function signature with type index :math:`\typeidx` must be empty.
 
-Exceptions are referenced through :ref:`exception indices <syntax-exnidx>`,
-starting with the smallest index not referencing an exception :ref:`import <syntax-import>`.
+Tags are referenced through :ref:`tag indices <syntax-tagidx>`,
+starting with the smallest index not referencing a tag :ref:`import <syntax-import>`.
 
 
 .. index:: ! global, global index, global type, mutability, expression, constant, value, import
@@ -358,11 +358,12 @@ The |MSTART| component of a module declares the :ref:`function index <syntax-fun
    The module and its exports are not accessible before this initialization has completed.
 
 
-.. index:: ! export, name, index, function index, table index, memory index, exception index, global index, function, table, memory, exception, global, instantiation
+.. index:: ! export, name, index, function index, table index, memory index, tag index, global index, function, table, memory, tag, global, instantiation
    pair: abstract syntax; export
    single: function; export
    single: table; export
    single: memory; export
+   single: tag; export
    single: global; export
 .. _syntax-exportdesc:
 .. _syntax-export:
@@ -380,12 +381,12 @@ The |MEXPORTS| component of a module defines a set of *exports* that become acce
      \EDFUNC~\funcidx \\&&|&
      \EDTABLE~\tableidx \\&&|&
      \EDMEM~\memidx \\&&|&
-     \EDEXN~\exnidx \\&&|&
+     \EDTAG~\tagidx \\&&|&
      \EDGLOBAL~\globalidx \\
    \end{array}
 
 Each export is labeled by a unique :ref:`name <syntax-name>`.
-Exportable definitions are :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`exceptions <syntax-exn>`, and :ref:`globals <syntax-global>`,
+Exportable definitions are :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`tags <syntax-tag>`, and :ref:`globals <syntax-global>`,
 which are referenced through a respective descriptor.
 
 
@@ -400,18 +401,18 @@ The following auxiliary notation is defined for sequences of exports, filtering 
 
 * :math:`\edmems(\export^\ast) = [\memidx ~|~ \EDMEM~\memidx \in (\export.\EDESC)^\ast]`
 
-* :math:`\edexns(\export^\ast) = [\exnidx ~|~ \EDEXN~\exnidx \in (\export.\EDESC)^\ast]`
+* :math:`\edtags(\export^\ast) = [\tagidx ~|~ \EDTAG~\tagidx \in (\export.\EDESC)^\ast]`
 
 * :math:`\edglobals(\export^\ast) = [\globalidx ~|~ \EDGLOBAL~\globalidx \in (\export.\EDESC)^\ast]`
 
 
-.. index:: ! import, name, function type, table type, memory type, global type, exception type, index space, type index, function index, table index, memory index, global index, exception index, function, table, memory, exception, global, instantiation
+.. index:: ! import, name, function type, table type, memory type, global type, tag type, index space, type index, function index, table index, memory index, global index, tag index, function, table, memory, tag, global, instantiation
    pair: abstract syntax; import
    single: function; import
    single: table; import
    single: memory; import
    single: global; import
-   single: exception; import
+   single: tag; import
 .. _syntax-importdesc:
 .. _syntax-import:
 
@@ -428,12 +429,12 @@ The |MIMPORTS| component of a module defines a set of *imports* that are require
      \IDFUNC~\typeidx \\&&|&
      \IDTABLE~\tabletype \\&&|&
      \IDMEM~\memtype \\&&|&
-     \IDEXN~\exntype \\&&|&
+     \IDTAG~\tagtype \\&&|&
      \IDGLOBAL~\globaltype \\
    \end{array}
 
 Each import is labeled by a two-level :ref:`name <syntax-name>` space, consisting of a |IMODULE| name and a |INAME| for an entity within that module.
-Importable definitions are :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`exceptions <syntax-exn>`, and :ref:`globals <syntax-global>`.
+Importable definitions are :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, :ref:`tags <syntax-tag>`, and :ref:`globals <syntax-global>`.
 Each import is specified by a descriptor with a respective type that a definition provided during instantiation is required to match.
 
 Every import defines an index in the respective :ref:`index space <syntax-index>`.

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -72,7 +72,7 @@ Conventions
 * The notation :math:`|t|` for :ref:`bit width <bitwidth>` extends to vector types as well, that is, :math:`|\V128| = 128`.
 
 
-.. index:: ! reference type, reference, table, function, function type, exception, exception type, null
+.. index:: ! reference type, reference, table, function, function type, null
    pair: abstract syntax; reference type
    pair: reference; type
 .. _syntax-reftype:
@@ -85,12 +85,10 @@ Reference Types
 .. math::
    \begin{array}{llll}
    \production{reference type} & \reftype &::=&
-     \FUNCREF ~|~ \EXNREF ~|~ \EXTERNREF \\
+     \FUNCREF ~|~ \EXTERNREF \\
    \end{array}
 
 The type |FUNCREF| denotes the infinite union of all references to :ref:`functions <syntax-func>`, regardless of their :ref:`function types <syntax-functype>`.
-
-The type |EXNREF| denotes a caught :ref:`exception <syntax-exn>`.
 
 The type |EXTERNREF| denotes the infinite union of all references to objects owned by the :ref:`embedder <embedder>` and that can be passed into WebAssembly under this type.
 
@@ -223,26 +221,28 @@ The limits are given in numbers of entries.
    In future versions of WebAssembly, additional element types may be introduced.
 
 
-.. index:: ! exception, exception type, function type
-   pair: abstract syntax; exception
-   single: exception; type
-.. _syntax-exntype:
+.. index:: ! tag, tag type, function type, exception tag
+   pair: abstract syntax; tag
+   pair: tag; exception tag
+   single: tag; type; exception
+.. _syntax-tagtype:
 
-Exception Types
-~~~~~~~~~~~~~~~
+Tag Types
+~~~~~~~~~
 
-*Exception types* classify the signature of :ref:`exceptions <syntax-exn>` with a function type.
+*Tag types* classify the signature of :ref:`tags <syntax-tag>` with a function type.
 
 .. math::
    \begin{array}{llll}
-   \production{exception type} &\exntype &::=& \functype \\
+   \production{tag type} &\tagtype &::=& \functype \\
    \end{array}
 
-The parameters of |functype| define the list of values associated with the exception.
-Furthermore, it is an invariant of the semantics that every |functype| in a :ref:`valid <valid-exntype>` exception type has an empty result type.
+Currently tags are only used for categorising exceptions.
+The parameters of |functype| define the list of values associated with the exception thrown with this tag.
+Furthermore, it is an invariant of the semantics that every |functype| in a :ref:`valid <valid-tagtype>` tag type for an exception has an empty result type.
 
 .. note::
-   Future versions of WebAssembly may allow non-empty result types in exceptions.
+   Future versions of WebAssembly may have additional uses for tags, and may allow non-empty result types in the function types of tags.
 
 
 .. index:: ! global type, ! mutability, value type, global, mutability
@@ -268,7 +268,7 @@ Global Types
    \end{array}
 
 
-.. index:: ! external type, function type, table type, memory type, exception type, global type, import, external value
+.. index:: ! external type, function type, table type, memory type, tag type, global type, import, external value
    pair: abstract syntax; external type
    pair: external; type
 .. _syntax-externtype:
@@ -284,7 +284,7 @@ External Types
      \ETFUNC~\functype ~|~
      \ETTABLE~\tabletype ~|~
      \ETMEM~\memtype ~|~
-     \ETEXN~\exntype ~|~
+     \ETTAG~\tagtype ~|~
      \ETGLOBAL~\globaltype \\
    \end{array}
 
@@ -301,6 +301,6 @@ It filters out entries of a specific kind in an order-preserving fashion:
 
 * :math:`\etmems(\externtype^\ast) = [\memtype ~|~ (\ETMEM~\memtype) \in \externtype^\ast]`
 
-* :math:`\etexns(\externtype^\ast) = [\exntype ~|~ (\ETEXN~\exntype) \in \externtype^\ast]`
+* :math:`\ettags(\externtype^\ast) = [\tagtype ~|~ (\ETTAG~\tagtype) \in \externtype^\ast]`
 
 * :math:`\etglobals(\externtype^\ast) = [\globaltype ~|~ (\ETGLOBAL~\globaltype) \in \externtype^\ast]`

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -237,7 +237,7 @@ Tag Types
    \production{tag type} &\tagtype &::=& \functype \\
    \end{array}
 
-Currently tags are only used for categorising exceptions.
+Currently tags are only used for categorizing exceptions.
 The parameters of |functype| define the list of values associated with the exception thrown with this tag.
 Furthermore, it is an invariant of the semantics that every |functype| in a :ref:`valid <valid-tagtype>` tag type for an exception has an empty result type.
 

--- a/document/core/text/conventions.rst
+++ b/document/core/text/conventions.rst
@@ -123,7 +123,7 @@ It is convenient to define identifier contexts as :ref:`records <notation-record
         & \IFUNCS & (\Tid^?)^\ast, \\
         & \ITABLES & (\Tid^?)^\ast, \\
         & \IMEMS & (\Tid^?)^\ast, \\
-        & \IEXNS & (\Tid^?)^\ast, \\
+        & \ITAGS & (\Tid^?)^\ast, \\
         & \IGLOBALS & (\Tid^?)^\ast, \\
         & \IELEM & (\Tid^?)^\ast, \\
         & \IDATA & (\Tid^?)^\ast, \\

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -43,7 +43,7 @@ The following grammar handles the corresponding update to the :ref:`identifier c
    mirroring the fact that control instructions are indexed relatively not absolutely.
 
 
-.. index:: control instructions, structured control, label, block, branch, result type, label index, function index, type index, vector, polymorphism, exception index, exception instructions
+.. index:: control instructions, structured control, label, block, branch, result type, label index, function index, type index, vector, polymorphism, tag index, exception instructions
    pair: text format; instruction
 .. _text-blockinstr:
 .. _text-plaininstr:
@@ -60,7 +60,7 @@ Control Instructions
 .. _text-try:
 
 :ref:`Structured control instructions <syntax-instr-control>` can bind an optional symbolic :ref:`label identifier <text-label>`.
-The same label identifier may optionally be repeated after the corresponding :math:`\T{end}`, :math:`\T{else}`, and :math:`\T{catch}`
+The same label identifier may optionally be repeated after the corresponding :math:`\T{end}`, :math:`\T{else}`, :math:`\T{catch}`, :math:`\T{catch\_all}`, and :math:`\T{delegate}`
 pseudo instructions, to indicate the matching delimiters.
 
 Their :ref:`block type <syntax-blocktype>` is given as a :ref:`type use <text-typeuse>`, analogous to the type of :ref:`functions <text-func>`.
@@ -86,10 +86,15 @@ However, the special case of a type use that is syntactically empty or consists 
        \text{else}~~\Tid_1^?~~(\X{in}_2{:}\Tinstr_{I'})^\ast~~\text{end}~~\Tid_2^?
        \\ &&&\qquad \Rightarrow\quad \IF~\X{bt}~\X{in}_1^\ast~\ELSE~\X{in}_2^\ast~\END
        \qquad (\iff \Tid_1^? = \epsilon \vee \Tid_1^? = \Tlabel, \Tid_2^? = \epsilon \vee \Tid_2^? = \Tlabel) \\ &&|&
-    \text{try}~~I'{:}\Tlabel_I~~\X{bt}{:}\Tblocktype~~(\X{in}_1{:}\Tinstr_{I'})^\ast~~
-       \text{catch}~~\Tid_1^?~~(\X{in}_2{:}\Tinstr_{I'})^\ast~~\text{end}~~\Tid_2^?
-       \\ &&&\qquad \Rightarrow\quad \TRY~\X{rt}~\X{in}_1^\ast~\CATCH~\X{in}_2^\ast~\END
-       \quad (\iff \Tid_1^? = \epsilon \vee \Tid_1^? = \Tlabel, \Tid_2^? = \epsilon \vee \Tid_2^? = \Tlabel) \\
+     \text{try}~~I'{:}\Tlabel_I~~\X{bt}{:}\Tblocktype~~(\X{in}_1{:}\Tinstr_{I'})^\ast~~
+       (\text{catch}~~\Tid_1^?~~x{:}\Ttagidx_I~~(\X{in}_2{:}\Tinstr_{I'})^\ast)^\ast~~
+       \\ &&&\qquad\qquad (\text{catch\_all}~~\Tid_1^?~~(\X{in}_3{:}\Tinstr_{I'})^\ast)^?~~\text{end}~~\Tid_2^?
+       \\ &&&\qquad \Rightarrow\quad \TRY~\X{rt}~\X{in}_1^\ast~(\CATCH~x~\X{in}_2^\ast)^\ast~(\CATCHALL~\X{in}_3^\ast)^?~\END
+       \\ &&&\qquad\qquad (\iff \Tid_1^? = \epsilon \vee \Tid_1^? = \Tlabel, \Tid_2^? = \epsilon \vee \Tid_2^? = \Tlabel) \\ &&|&
+     \text{try}~~I'{:}\Tlabel_I~~\X{bt}{:}\Tblocktype~~(\X{in}_1{:}\Tinstr_{I'})^\ast
+       ~~\text{delegate}~~l{:}\Tlabelidx_I~~\X{l}{:}\Tlabelidx_I
+       \\ &&&\qquad \Rightarrow\quad \TRY~\X{rt}~\X{in}_1^\ast~\DELEGATE~l
+       \qquad\quad~~ (\iff \Tid^? = \epsilon \vee \Tid^? = \Tlabel) \\
    \end{array}
 
 .. note::
@@ -100,7 +105,6 @@ However, the special case of a type use that is syntactically empty or consists 
 .. _text-unreachable:
 .. _text-throw:
 .. _text-rethrow:
-.. _text-br_on_exn:
 .. _text-br:
 .. _text-br_if:
 .. _text-br_table:
@@ -115,9 +119,8 @@ All other control instruction are represented verbatim.
    \production{plain instruction} & \Tplaininstr_I &::=&
      \text{unreachable} &\Rightarrow& \UNREACHABLE \\ &&|&
      \text{nop} &\Rightarrow& \NOP \\ &&|&
-     \text{throw}~~\text{(}\text{exception}~x{:}\Texnidx_I\text{)} &\Rightarrow& \THROW~x \\ &&|&
-     \text{rethrow} &\Rightarrow& \RETHROW \\ &&|&
-     \text{br\_on\_exn}~~l{:}\Tlabelidx_I~~\text{(}\text{exception}~x{:}\Texnidx_I~\text{)} &\Rightarrow& \BRONEXN~l~x \\ &&|&
+     \text{throw}~~x{:}\Ttagidx_I &\Rightarrow& \THROW~x \\ &&|&
+     \text{rethrow}~~l{:}\Tlabelidx_I &\Rightarrow& \RETHROW~l \\ &&|&
      \text{br}~~l{:}\Tlabelidx_I &\Rightarrow& \BR~l \\ &&|&
      \text{br\_if}~~l{:}\Tlabelidx_I &\Rightarrow& \BRIF~l \\ &&|&
      \text{br\_table}~~l^\ast{:}\Tvec(\Tlabelidx_I)~~l_N{:}\Tlabelidx_I
@@ -926,14 +929,18 @@ Such a folded instruction can appear anywhere a regular instruction can.
      \text{(}~\text{block}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~\text{)}
        &\equiv\quad \text{block}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\ &
      \text{(}~\text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~\text{)}
-       &\equiv\quad \text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\ &
+       &\equiv\quad \text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\
+   \end{array}\\
+   \begin{array}{lr}
      \text{(}~\text{if}~~\Tlabel~~\Tblocktype~~\Tfoldedinstr^\ast
-       &\hspace{-3ex} \text{(}~\text{then}~~\Tinstr_1^\ast~\text{)}~~\text{(}~\text{else}~~\Tinstr_2^\ast~\text{)}^?~~\text{)}
-       \quad\equiv \\ &\qquad
-         \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype &\hspace{-1ex} \Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~\text{end} \\ &
+       \text{(}~\text{then}~~\Tinstr_1^\ast~\text{)}~~\text{(}~\text{else}~~\Tinstr_2^\ast~\text{)}^?~~\text{)}
+       & \equiv \\
+       \qquad \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype \Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~\text{end} &\\
      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}
-       &\hspace{-8ex} \text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)}~\text{)} \quad\equiv \\ &\qquad
-       \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast & \hspace{-6ex} \text{catch}~~\Tinstr_2^\ast~\text{end} & \\
+       \qquad (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
+       \qquad\qquad (\text{(}~\text{catch_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\
+     \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast (\text{delegate}~~\Tlabelidx & \equiv \\
+       \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{delegate}~~l~\text{)} &\\
    \end{array}
 
 .. note::

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -89,11 +89,11 @@ However, the special case of a type use that is syntactically empty or consists 
      \text{try}~~I'{:}\Tlabel_I~~\X{bt}{:}\Tblocktype~~(\X{in}_1{:}\Tinstr_{I'})^\ast~~
        (\text{catch}~~\Tid_1^?~~x{:}\Ttagidx_I~~(\X{in}_2{:}\Tinstr_{I'})^\ast)^\ast~~
        \\ &&&\qquad\qquad (\text{catch\_all}~~\Tid_1^?~~(\X{in}_3{:}\Tinstr_{I'})^\ast)^?~~\text{end}~~\Tid_2^?
-       \\ &&&\qquad \Rightarrow\quad \TRY~\X{rt}~\X{in}_1^\ast~(\CATCH~x~\X{in}_2^\ast)^\ast~(\CATCHALL~\X{in}_3^\ast)^?~\END
+       \\ &&&\qquad \Rightarrow\quad \TRY~\X{bt}~\X{in}_1^\ast~(\CATCH~x~\X{in}_2^\ast)^\ast~(\CATCHALL~\X{in}_3^\ast)^?~\END
        \\ &&&\qquad\qquad (\iff \Tid_1^? = \epsilon \vee \Tid_1^? = \Tlabel, \Tid_2^? = \epsilon \vee \Tid_2^? = \Tlabel) \\ &&|&
      \text{try}~~I'{:}\Tlabel_I~~\X{bt}{:}\Tblocktype~~(\X{in}_1{:}\Tinstr_{I'})^\ast
        ~~\text{delegate}~~l{:}\Tlabelidx_I~~\X{l}{:}\Tlabelidx_I
-       \\ &&&\qquad \Rightarrow\quad \TRY~\X{rt}~\X{in}_1^\ast~\DELEGATE~l
+       \\ &&&\qquad \Rightarrow\quad \TRY~\X{bt}~\X{in}_1^\ast~\DELEGATE~l
        \qquad\quad~~ (\iff \Tid^? = \epsilon \vee \Tid^? = \Tlabel) \\
    \end{array}
 
@@ -932,15 +932,17 @@ Such a folded instruction can appear anywhere a regular instruction can.
        &\equiv\quad \text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\
    \end{array}\\
    \begin{array}{lr}
-     \text{(}~\text{if}~~\Tlabel~~\Tblocktype~~\Tfoldedinstr^\ast
+     \text{(}~\text{if}~~\Tlabel~~\Tblocktype~~\Tfoldedinstr^\ast~~
        \text{(}~\text{then}~~\Tinstr_1^\ast~\text{)}~~\text{(}~\text{else}~~\Tinstr_2^\ast~\text{)}^?~~\text{)}
        & \equiv \\
-       \qquad \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype \Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~\text{end} &\\
+       \qquad \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~~\text{end} &\\
      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}
-       \qquad (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
-       \qquad\qquad (\text{(}~\text{catch_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\
-     \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast (\text{delegate}~~\Tlabelidx & \equiv \\
-       \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{delegate}~~l~\text{)} &\\
++     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}~~
++       (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
++       \qquad\qquad(\text{(}~\text{catch\_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\
++       \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~(\text{catch}~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} &\\
++     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{delegate}~~l~\text{)} & \equiv \\
++       \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{delegate}~~\Tlabelidx &\\
    \end{array}
 
 .. note::

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -929,20 +929,24 @@ Such a folded instruction can appear anywhere a regular instruction can.
      \text{(}~\text{block}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~\text{)}
        &\equiv\quad \text{block}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\ &
      \text{(}~\text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~\text{)}
-       &\equiv\quad \text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\
-   \end{array}\\
-   \begin{array}{lr}
-     \text{(}~\text{if}~~\Tlabel~~\Tblocktype~~\Tfoldedinstr^\ast~~
-       \text{(}~\text{then}~~\Tinstr_1^\ast~\text{)}~~\text{(}~\text{else}~~\Tinstr_2^\ast~\text{)}^?~~\text{)}
-       & \equiv \\
-       \qquad \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~~\text{end} &\\
-      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}~~
-        (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
-        \qquad\qquad(\text{(}~\text{catch\_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\
-        \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~(\text{catch}~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} &\\
-      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{delegate}~~l~\text{)} & \equiv \\
-        \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{delegate}~~\Tlabelidx &\\
+       &\equiv\quad \text{loop}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{end} \\ &
+     \text{(}~\text{if}~~\Tlabel~~\Tblocktype~~\Tfoldedinstr^\ast
+       &\hspace{-1ex} \text{(}~\text{then}~~\Tinstr_1^\ast~\text{)}~~(\text{(}~\text{else}~~\Tinstr_2^\ast~\text{)})^?~~\text{)}
+       \quad\equiv \\ &\qquad
+       \Tfoldedinstr^\ast~~\text{if}~~\Tlabel
+       &\hspace{-12ex} \Tblocktype~~\Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~\text{end} \\ &
+     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do} &\hspace{-8ex} \Tinstr_1^\ast~\text{)}~~
+       (\text{(}~\text{catch}~~x{:}\Ttagidx_I~~\Tinstr_2^\ast~\text{)})^\ast \\ &\quad
+       (\text{(}~\text{catch\_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)}
+       \quad\equiv \\ &\qquad
+         \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast
+       &\hspace{-5ex} (\text{catch}~~x{:}\Ttagidx_I~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} \\ &
+      \text{(}~\text{try}~~\Tlabel~~\Tblocktype
+       &\hspace{-15ex} \text{(}~\text{delegate}~~l{:}\Tlabelidx~~\Tinstr^\ast~~\text{)}~\text{)}
+       \quad\equiv \\ &\qquad
+         \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast &\hspace{-5ex} \text{delegate}~~l{:}\Tlabelidx \\
    \end{array}
+
 
 .. note::
    For example, the instruction sequence

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -941,8 +941,8 @@ Such a folded instruction can appear anywhere a regular instruction can.
        \quad\equiv \\ &\qquad
          \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast
        &\hspace{-5ex} (\text{catch}~~x{:}\Ttagidx_I~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} \\ &
-      \text{(}~\text{try}~~\Tlabel~~\Tblocktype
-       &\hspace{-15ex} \text{(}~\text{delegate}~~l{:}\Tlabelidx~~\Tinstr^\ast~~\text{)}~\text{)}
++     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do} &\hspace{-8ex} \Tinstr^\ast~\text{)}~~
++       \text{(}~\text{delegate}~~l{:}\Tlabelidx~~\text{)}
        \quad\equiv \\ &\qquad
          \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast &\hspace{-5ex} \text{delegate}~~l{:}\Tlabelidx \\
    \end{array}

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -937,12 +937,12 @@ Such a folded instruction can appear anywhere a regular instruction can.
        & \equiv \\
        \qquad \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~~\text{end} &\\
      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}
-+     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}~~
-+       (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
-+       \qquad\qquad(\text{(}~\text{catch\_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\
-+       \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~(\text{catch}~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} &\\
-+     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{delegate}~~l~\text{)} & \equiv \\
-+       \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{delegate}~~\Tlabelidx &\\
+      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}~~
+        (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
+        \qquad\qquad(\text{(}~\text{catch\_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\
+        \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~(\text{catch}~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} &\\
+      \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{delegate}~~l~\text{)} & \equiv \\
+        \qquad\text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast~~\text{delegate}~~\Tlabelidx &\\
    \end{array}
 
 .. note::

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -941,8 +941,8 @@ Such a folded instruction can appear anywhere a regular instruction can.
        \quad\equiv \\ &\qquad
          \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast
        &\hspace{-5ex} (\text{catch}~~x{:}\Ttagidx_I~~\Tinstr_2^\ast)^\ast~~(\text{catch\_all}~~\Tinstr_3^\ast)^?~~\text{end} \\ &
-+     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do} &\hspace{-8ex} \Tinstr^\ast~\text{)}~~
-+       \text{(}~\text{delegate}~~l{:}\Tlabelidx~~\text{)}
+     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do} &\hspace{-8ex} \Tinstr^\ast~\text{)}~~
+       \text{(}~\text{delegate}~~l{:}\Tlabelidx~~\text{)}~\text{)}
        \quad\equiv \\ &\qquad
          \text{try}~~\Tlabel~~\Tblocktype~~\Tinstr^\ast &\hspace{-5ex} \text{delegate}~~l{:}\Tlabelidx \\
    \end{array}

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -936,7 +936,6 @@ Such a folded instruction can appear anywhere a regular instruction can.
        \text{(}~\text{then}~~\Tinstr_1^\ast~\text{)}~~\text{(}~\text{else}~~\Tinstr_2^\ast~\text{)}^?~~\text{)}
        & \equiv \\
        \qquad \Tfoldedinstr^\ast~~\text{if}~~\Tlabel~~\Tblocktype~~\Tinstr_1^\ast~~\text{else}~~(\Tinstr_2^\ast)^?~~\text{end} &\\
-     \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}
       \text{(}~\text{try}~~\Tlabel~~\Tblocktype~~\text{(}~\text{do}~~\Tinstr_1^\ast~~\text{)}~~
         (\text{(}~\text{catch}~~\Tinstr_2^\ast~\text{)})^\ast &\\
         \qquad\qquad(\text{(}~\text{catch\_all}~~\Tinstr_3^\ast~\text{)})^?~\text{)} & \equiv \\

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -428,7 +428,7 @@ Tags can be defined as :ref:`imports <text-import>` or :ref:`exports <text-expor
        \text{(}~\text{export}~~\Tname~~\text{(}~\text{tag}~~\Tid'~\text{)}~\text{)}~~
        \text{(}~\text{tag}~~\Tid'~~\dots~\text{)}
        \\ & \qquad\qquad
-       (\iff \Tid' = \Tid^? \neq \epsilon \vee \Tid' \idfresh) \\
+       (\iff \Tid^? \neq \epsilon \wedge \Tid' = \Tid^? \vee \Tid^? = \epsilon \wedge \Tid' \idfresh) \\
    \end{array}
 
 The latter abbreviation can be applied repeatedly, with ":math:`\dots`" containing another import or export.

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -2,12 +2,12 @@ Modules
 -------
 
 
-.. index:: index, type index, function index, table index, memory index, exception index, global index, element index, data index, local index, label index
+.. index:: index, type index, function index, table index, memory index, tag index, global index, element index, data index, local index, label index
    pair: text format; type index
    pair: text format; function index
    pair: text format; table index
    pair: text format; memory index
-   pair: text format; exception index
+   pair: text format; tag index
    pair: text format; global index
    pair: text format; element index
    pair: text format; data index
@@ -17,7 +17,7 @@ Modules
 .. _text-funcidx:
 .. _text-tableidx:
 .. _text-memidx:
-.. _text-exnidx:
+.. _text-tagidx:
 .. _text-elemidx:
 .. _text-dataidx:
 .. _text-globalidx:
@@ -45,9 +45,9 @@ Such identifiers are looked up in the suitable space of the :ref:`identifier con
    \production{memory index} & \Tmemidx_I &::=&
      x{:}\Tu32 &\Rightarrow& x \\&&|&
      v{:}\Tid &\Rightarrow& x & (\iff I.\IMEMS[x] = v) \\
-   \production{exception index} & \Texnidx_I &::=&
+   \production{tag index} & \Ttagidx_I &::=&
      x{:}\Tu32 &\Rightarrow& x \\&&|&
-     v{:}\Tid &\Rightarrow& x & (\iff I.\IEXNS[x] = v) \\
+     v{:}\Tid &\Rightarrow& x & (\iff I.\ITAGS[x] = v) \\
    \production{global index} & \Tglobalidx_I &::=&
      x{:}\Tu32 &\Rightarrow& x \\&&|&
      v{:}\Tid &\Rightarrow& x & (\iff I.\IGLOBALS[x] = v) \\
@@ -154,7 +154,7 @@ is inserted at the end of the module.
 Abbreviations are expanded in the order they appear, such that previously inserted type definitions are reused by consecutive expansions.
 
 
-.. index:: import, name, function type, table type, memory type, exception type, global type
+.. index:: import, name, function type, table type, memory type, tag type, global type
    pair: text format; import
 .. _text-importdesc:
 .. _text-import:
@@ -162,7 +162,7 @@ Abbreviations are expanded in the order they appear, such that previously insert
 Imports
 ~~~~~~~
 
-The descriptors in imports can bind a symbolic function, table, memory, exception, or global :ref:`identifier <text-id>`.
+The descriptors in imports can bind a symbolic function, table, memory, tag, or global :ref:`identifier <text-id>`.
 
 .. math::
    \begin{array}{llclll}
@@ -176,8 +176,8 @@ The descriptors in imports can bind a symbolic function, table, memory, exceptio
        &\Rightarrow& \IDTABLE~\X{tt} \\ &&|&
      \text{(}~\text{memory}~~\Tid^?~~\X{mt}{:}\Tmemtype~\text{)}
        &\Rightarrow& \IDMEM~~\X{mt} \\ &&|&
-     \text{(}~\text{exception}~~\Tid^?~~\X{et}{:}\Texn~\text{)}
-       &\Rightarrow& \IDEXN~\X{et} \\ &&|&
+     \text{(}~\text{tag}~~\Tid^?~~\X{tt}{:}\Ttag~\text{)}
+       &\Rightarrow& \IDTAG~\X{tt} \\ &&|&
      \text{(}~\text{global}~~\Tid^?~~\X{gt}{:}\Tglobaltype~\text{)}
        &\Rightarrow& \IDGLOBAL~\X{gt} \\
    \end{array}
@@ -186,7 +186,7 @@ The descriptors in imports can bind a symbolic function, table, memory, exceptio
 Abbreviations
 .............
 
-As an abbreviation, imports may also be specified inline with :ref:`function <text-func>`, :ref:`table <text-table>`, :ref:`memory <text-mem>`, :ref:`exception <text-exn>` or :ref:`global <text-global>` definitions; see the respective sections.
+As an abbreviation, imports may also be specified inline with :ref:`function <text-func>`, :ref:`table <text-table>`, :ref:`memory <text-mem>`, :ref:`tag <text-tag>` or :ref:`global <text-global>` definitions; see the respective sections.
 
 
 
@@ -389,44 +389,44 @@ Memories can be defined as :ref:`imports <text-import>` or :ref:`exports <text-e
 The latter abbreviation can be applied repeatedly, with ":math:`\dots`" containing another import or export or an inline data segment.
 
 
-.. index:: exception, exception type, identifier, function type
-   pair: text format; exception
-.. _text-exn:
+.. index:: tag, tag type, identifier, function type, exception tag
+   pair: text format; tag
+.. _text-tag:
 
-Exceptions
-~~~~~~~~~~
+Tags
+~~~~
 
-An exception definition can bind a symbolic :ref:`exception identifier <text-id>`.
+An tag definition can bind a symbolic :ref:`tag identifier <text-id>`.
 
 .. math::
    \begin{array}{llcl}
-   \production{exception} & \Texn_I &::=&
-     \text{(}~\text{exception}~~\Tid^?~~x,I'{:}\Ttypeuse_I~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETYPE~x \} \\
+   \production{tag} & \Ttag_I &::=&
+     \text{(}~\text{tag}~~\Tid^?~~x,I'{:}\Ttypeuse_I~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \TAGTYPE~x \} \\
    \end{array}
 
 
 .. index:: import, name
    pair: text format; import
-.. index:: export, name, index, exception index
+.. index:: export, name, index, tag index
    pair: text format; export
-.. index:: exception
-.. _text-exn-abbrev:
+.. index:: tag
+.. _text-tag-abbrev:
 
 Abbreviations
 .............
 
-Exceptions can be defined as :ref:`imports <text-import>` or :ref:`exports <text-export>` inline:
+Tags can be defined as :ref:`imports <text-import>` or :ref:`exports <text-export>` inline:
 
 .. math::
    \begin{array}{llclll}
    \production{module field} &
-     \text{(}~\text{exception}~~\Tid^?~~\text{(}~\text{import}~~\Tname_1~~\Tname_2~\text{)}~~\Ttypeuse~\text{)} \quad\equiv \\ & \qquad
-       \text{(}~\text{import}~~\Tname_1~~\Tname_2~~\text{(}~\text{exception}~~\Tid^?~~\Ttypeuse~\text{)}~\text{)}
+     \text{(}~\text{tag}~~\Tid^?~~\text{(}~\text{import}~~\Tname_1~~\Tname_2~\text{)}~~\Ttypeuse~\text{)} \quad\equiv \\ & \qquad
+       \text{(}~\text{import}~~\Tname_1~~\Tname_2~~\text{(}~\text{tag}~~\Tid^?~~\Ttypeuse~\text{)}~\text{)}
        \\[1ex] &
-     \text{(}~\text{exception}~~\Tid^?~~\text{(}~\text{export}~~\Tname~\text{)}~~\dots~\text{)} \quad\equiv \\ & \qquad
-       \text{(}~\text{export}~~\Tname~~\text{(}~\text{exception}~~\Tid'~\text{)}~\text{)}~~
-       \text{(}~\text{exception}~~\Tid'~~\dots~\text{)}
+     \text{(}~\text{tag}~~\Tid^?~~\text{(}~\text{export}~~\Tname~\text{)}~~\dots~\text{)} \quad\equiv \\ & \qquad
+       \text{(}~\text{export}~~\Tname~~\text{(}~\text{tag}~~\Tid'~\text{)}~\text{)}~~
+       \text{(}~\text{tag}~~\Tid'~~\dots~\text{)}
        \\ & \qquad\qquad
        (\iff \Tid' = \Tid^? \neq \epsilon \vee \Tid' \idfresh) \\
    \end{array}
@@ -478,7 +478,7 @@ Globals can be defined as :ref:`imports <text-import>` or :ref:`exports <text-ex
 The latter abbreviation can be applied repeatedly, with ":math:`\dots`" containing another import or export.
 
 
-.. index:: export, name, index, function index, table index, memory index, exception index, global index
+.. index:: export, name, index, function index, table index, memory index, tag index, global index
    pair: text format; export
 .. _text-exportdesc:
 .. _text-export:
@@ -500,8 +500,8 @@ The syntax for exports mirrors their :ref:`abstract syntax <syntax-export>` dire
        &\Rightarrow& \EDTABLE~x \\ &&|&
      \text{(}~\text{memory}~~x{:}\Tmemidx_I~\text{)}
        &\Rightarrow& \EDMEM~x \\ &&|&
-     \text{(}~\text{exception}~~x{:}\Texnidx_I~\text{)}
-       &\Rightarrow& \EDEXN~x \\&&|&
+     \text{(}~\text{tag}~~x{:}\Ttagidx_I~\text{)}
+       &\Rightarrow& \EDTAG~x \\&&|&
      \text{(}~\text{global}~~x{:}\Tglobalidx_I~\text{)}
        &\Rightarrow& \EDGLOBAL~x \\
    \end{array}
@@ -510,7 +510,7 @@ The syntax for exports mirrors their :ref:`abstract syntax <syntax-export>` dire
 Abbreviations
 .............
 
-As an abbreviation, exports may also be specified inline with :ref:`function <text-func>`, :ref:`table <text-table>`, :ref:`memory <text-mem>`, :ref:`exception <text-exn>` definitions, or :ref:`global <text-global>` definitions; see the respective sections.
+As an abbreviation, exports may also be specified inline with :ref:`function <text-func>`, :ref:`table <text-table>`, :ref:`memory <text-mem>`, :ref:`tag <text-tag>` definitions, or :ref:`global <text-global>` definitions; see the respective sections.
 
 
 .. index:: start function, function index
@@ -665,7 +665,7 @@ Also, a memory use can be omitted, defaulting to :math:`\T{0}`.
 As another abbreviation, data segments may also be specified inline with :ref:`memory <text-mem>` definitions; see the respective section.
 
 
-.. index:: module, type definition, function type, function, table, memory, exception, global, element, data, start function, import, export, identifier context, identifier, name section
+.. index:: module, type definition, function type, function, table, memory, tag, global, element, data, start function, import, export, identifier context, identifier, name section
    pair: text format; module
    single: section; name
 .. _text-modulefield:
@@ -700,7 +700,7 @@ The name serves a documentary role only.
      \X{fn}{:}\Tfunc_I &\Rightarrow& \{\MFUNCS~\X{fn}\} \\ |&
      \X{ta}{:}\Ttable_I &\Rightarrow& \{\MTABLES~\X{ta}\} \\ |&
      \X{me}{:}\Tmem_I &\Rightarrow& \{\MMEMS~\X{me}\} \\ |&
-     \X{et}{:}\Texn_I &\Rightarrow& \{\MEXNS~\X{et}\} \\ |&
+     \X{tt}{:}\Ttag_I &\Rightarrow& \{\MTAGS~\X{tt}\} \\ |&
      \X{gl}{:}\Tglobal_I &\Rightarrow& \{\MGLOBALS~\X{gl}\} \\ |&
      \X{ex}{:}\Texport_I &\Rightarrow& \{\MEXPORTS~\X{ex}\} \\ |&
      \X{st}{:}\Tstart_I &\Rightarrow& \{\MSTART~\X{st}\} \\ |&
@@ -713,11 +713,11 @@ The following restrictions are imposed on the composition of :ref:`modules <synt
 
 * :math:`m_1.\MSTART = \epsilon \vee m_2.\MSTART = \epsilon`
 
-* :math:`m_1.\MFUNCS = m_1.\MTABLES = m_1.\MMEMS = m_1.\MEXNS = m_1.\MGLOBALS = \epsilon \vee m_2.\MIMPORTS = \epsilon`
+* :math:`m_1.\MFUNCS = m_1.\MTABLES = m_1.\MMEMS = m_1.\MTAGS = m_1.\MGLOBALS = \epsilon \vee m_2.\MIMPORTS = \epsilon`
 
 .. note::
    The first condition ensures that there is at most one start function.
-   The second condition enforces that all :ref:`imports <text-import>` must occur before any regular definition of a :ref:`function <text-func>`, :ref:`table <text-table>`, :ref:`memory <text-mem>`, :ref:`exception <text-exn>`, or :ref:`global <text-global>`,
+   The second condition enforces that all :ref:`imports <text-import>` must occur before any regular definition of a :ref:`function <text-func>`, :ref:`table <text-table>`, :ref:`memory <text-mem>`, :ref:`tag <text-tag>`, or :ref:`global <text-global>`,
    thereby maintaining the ordering of the respective :ref:`index spaces <syntax-index>`.
 
    The :ref:`well-formedness <text-context-wf>` condition on :math:`I` in the grammar for |Tmodule| ensures that no namespace contains duplicate identifiers.
@@ -734,8 +734,8 @@ The definition of the initial :ref:`identifier context <text-context>` :math:`I`
      \{\ITABLES~(\Tid^?)\} \\
    \F{idc}(\text{(}~\text{memory}~\Tid^?~\dots~\text{)}) &=&
      \{\IMEMS~(\Tid^?)\} \\
-   \F{idc}(\text{(}~\text{exception}~\Tid^?~\dots~\text{)}) &=&
-     \{\IEXNS~(\Tid^?)\} \\
+   \F{idc}(\text{(}~\text{tag}~\Tid^?~\dots~\text{)}) &=&
+     \{\ITAGS~(\Tid^?)\} \\
    \F{idc}(\text{(}~\text{global}~\Tid^?~\dots~\text{)}) &=&
      \{\IGLOBALS~(\Tid^?)\} \\
    \F{idc}(\text{(}~\text{elem}~\Tid^?~\dots~\text{)}) &=&
@@ -748,8 +748,8 @@ The definition of the initial :ref:`identifier context <text-context>` :math:`I`
      \{\ITABLES~(\Tid^?)\} \\
    \F{idc}(\text{(}~\text{import}~\dots~\text{(}~\text{memory}~\Tid^?~\dots~\text{)}~\text{)}) &=&
      \{\IMEMS~(\Tid^?)\} \\
-   \F{idc}(\text{(}~\text{import}~\dots~\text{(}~\text{exception}~\Tid^?~\dots~\text{)}~\text{)}) &=&
-     \{\IEXNS~(\Tid^?)\} \\
+   \F{idc}(\text{(}~\text{import}~\dots~\text{(}~\text{tag}~\Tid^?~\dots~\text{)}~\text{)}) &=&
+     \{\ITAGS~(\Tid^?)\} \\
    \F{idc}(\text{(}~\text{import}~\dots~\text{(}~\text{global}~\Tid^?~\dots~\text{)}~\text{)}) &=&
      \{\IGLOBALS~(\Tid^?)\} \\
    \F{idc}(\text{(}~\dots~\text{)}) &=&

--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -48,11 +48,9 @@ Reference Types
    \begin{array}{llcll@{\qquad\qquad}l}
    \production{reference type} & \Treftype &::=&
      \text{funcref} &\Rightarrow& \FUNCREF \\ &&|&
-     \text{exnref} &\Rightarrow& \EXNREF \\ &&|&
      \text{externref} &\Rightarrow& \EXTERNREF \\
    \production{heap type} & \Theaptype &::=&
      \text{func} &\Rightarrow& \FUNCREF \\ &&|&
-     \text{exn} &\Rightarrow& \EXNREF \\ &&|&
      \text{extern} &\Rightarrow& \EXTERNREF \\
    \end{array}
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -894,11 +894,8 @@
 
 .. |ok| mathdef:: \mathrel{\mbox{ok}}
 .. |const| mathdef:: \xref{valid/instructions}{valid-constant}{\mathrel{\mbox{const}}}
-.. |catch| mathdef:: \xref{valid/conventions}{valid-labelkind}{\mathrel{\mbox{catch}}}
 
-.. |labelkind| mathdef:: \xref{valid/conventions}{valid-labelkind}{\mathrel{\X{labelkind}}}
-
-.. Contexts
+.. Contexts, terminals
 
 .. |CTYPES| mathdef:: \xref{valid/conventions}{context}{\K{types}}
 .. |CFUNCS| mathdef:: \xref{valid/conventions}{context}{\K{funcs}}
@@ -912,6 +909,11 @@
 .. |CLABELS| mathdef:: \xref{valid/conventions}{context}{\K{labels}}
 .. |CRETURN| mathdef:: \xref{valid/conventions}{context}{\K{return}}
 .. |CREFS| mathdef:: \xref{valid/conventions}{context}{\K{refs}}
+.. |LCATCH| mathdef:: \xref{valid/conventions}{valid-labeltype}{\mathrel{\K{catch}}}
+
+.. Contexts, non-terminals
+
+.. |labeltype| mathdef:: \xref{valid/conventions}{valid-labeltype}{\mathrel{\X{labeltype}}}
 
 
 .. Judgments
@@ -1316,5 +1318,3 @@
 
 .. |error| mathdef:: \xref{appendix/embedding}{embed-error}{\X{error}}
 .. |ERROR| mathdef:: \xref{appendix/embedding}{embed-error}{\K{error}}
-.. |exception| mathdef:: \xref{appendix/embedding}{embed-exception}{\X{exception}}
-.. |EXCEPTION| mathdef:: \xref{appendix/embedding}{embed-exception}{\K{exception}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -190,7 +190,6 @@
 
 .. |FUNCREF| mathdef:: \xref{syntax/types}{syntax-reftype}{\K{funcref}}
 .. |EXTERNREF| mathdef:: \xref{syntax/types}{syntax-reftype}{\K{externref}}
-.. |EXNREF| mathdef:: \xref{syntax/types}{syntax-reftype}{\K{exnref}}
 
 .. |MVAR| mathdef:: \xref{syntax/types}{syntax-mut}{\K{var}}
 .. |MCONST| mathdef:: \xref{syntax/types}{syntax-mut}{\K{const}}
@@ -202,7 +201,7 @@
 .. |ETTABLE| mathdef:: \xref{syntax/types}{syntax-externtype}{\K{table}}
 .. |ETMEM| mathdef:: \xref{syntax/types}{syntax-externtype}{\K{mem}}
 .. |ETGLOBAL| mathdef:: \xref{syntax/types}{syntax-externtype}{\K{global}}
-.. |ETEXN| mathdef:: \xref{syntax/types}{syntax-externtype}{\K{exception}}
+.. |ETTAG| mathdef:: \xref{syntax/types}{syntax-tagtype}{\K{tag}}
 
 
 .. Types, non-terminals
@@ -213,7 +212,7 @@
 .. |valtype| mathdef:: \xref{syntax/types}{syntax-valtype}{\X{valtype}}
 .. |resulttype| mathdef:: \xref{syntax/types}{syntax-resulttype}{\X{resulttype}}
 .. |functype| mathdef:: \xref{syntax/types}{syntax-functype}{\X{functype}}
-.. |exntype| mathdef:: \xref{syntax/types}{syntax-exntype}{\X{exntype}}
+.. |tagtype| mathdef:: \xref{syntax/types}{syntax-tagtype}{\X{tagtype}}
 
 .. |globaltype| mathdef:: \xref{syntax/types}{syntax-globaltype}{\X{globaltype}}
 .. |tabletype| mathdef:: \xref{syntax/types}{syntax-tabletype}{\X{tabletype}}
@@ -234,7 +233,7 @@
 .. |ettables| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{tables}}
 .. |etmems| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{mems}}
 .. |etglobals| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{globals}}
-.. |etexns| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{exceptions}}
+.. |ettags| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{tags}}
 
 
 .. Indices, non-terminals
@@ -248,7 +247,7 @@
 .. |dataidx| mathdef:: \xref{syntax/modules}{syntax-dataidx}{\X{dataidx}}
 .. |localidx| mathdef:: \xref{syntax/modules}{syntax-localidx}{\X{localidx}}
 .. |labelidx| mathdef:: \xref{syntax/modules}{syntax-labelidx}{\X{labelidx}}
-.. |exnidx| mathdef:: \xref{syntax/modules}{syntax-exnidx}{\X{exnidx}}
+.. |tagidx| mathdef:: \xref{syntax/modules}{syntax-tagidx}{\X{tagidx}}
 
 
 .. Indices, meta functions
@@ -271,7 +270,7 @@
 .. |MTABLES| mathdef:: \xref{syntax/modules}{syntax-module}{\K{tables}}
 .. |MMEMS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{mems}}
 .. |MGLOBALS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{globals}}
-.. |MEXNS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{exceptions}}
+.. |MTAGS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{tags}}
 .. |MIMPORTS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{imports}}
 .. |MEXPORTS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{exports}}
 .. |MDATAS| mathdef:: \xref{syntax/modules}{syntax-module}{\K{datas}}
@@ -286,7 +285,7 @@
 
 .. |MTYPE| mathdef:: \xref{syntax/modules}{syntax-mem}{\K{type}}
 
-.. |ETYPE| mathdef:: \xref{syntax/modules}{syntax-exn}{\K{type}}
+.. |TAGTYPE| mathdef:: \xref{syntax/modules}{syntax-tag}{\K{type}}
 
 .. |GTYPE| mathdef:: \xref{syntax/modules}{syntax-global}{\K{type}}
 .. |GINIT| mathdef:: \xref{syntax/modules}{syntax-global}{\K{init}}
@@ -315,7 +314,7 @@
 .. |EDTABLE| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\K{table}}
 .. |EDMEM| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\K{mem}}
 .. |EDGLOBAL| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\K{global}}
-.. |EDEXN| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\K{exception}}
+.. |EDTAG| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\K{tag}}
 
 .. |IMODULE| mathdef:: \xref{syntax/modules}{syntax-import}{\K{module}}
 .. |INAME| mathdef:: \xref{syntax/modules}{syntax-import}{\K{name}}
@@ -323,7 +322,7 @@
 .. |IDFUNC| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\K{func}}
 .. |IDTABLE| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\K{table}}
 .. |IDMEM| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\K{mem}}
-.. |IDEXN| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\K{exception}}
+.. |IDTAG| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\K{tag}}
 .. |IDGLOBAL| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\K{global}}
 
 
@@ -334,7 +333,7 @@
 .. |func| mathdef:: \xref{syntax/modules}{syntax-func}{\X{func}}
 .. |table| mathdef:: \xref{syntax/modules}{syntax-table}{\X{table}}
 .. |mem| mathdef:: \xref{syntax/modules}{syntax-mem}{\X{mem}}
-.. |exn| mathdef:: \xref{syntax/modules}{syntax-exn}{\X{exn}}
+.. |tag| mathdef:: \xref{syntax/modules}{syntax-tag}{\X{tag}}
 .. |global| mathdef:: \xref{syntax/modules}{syntax-global}{\X{global}}
 .. |import| mathdef:: \xref{syntax/modules}{syntax-import}{\X{import}}
 .. |export| mathdef:: \xref{syntax/modules}{syntax-export}{\X{export}}
@@ -352,7 +351,7 @@
 .. |edfuncs| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\F{funcs}}
 .. |edtables| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\F{tables}}
 .. |edmems| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\F{mems}}
-.. |edexns| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\F{exceptions}}
+.. |edtags| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\F{tags}}
 .. |edglobals| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\F{globals}}
 
 
@@ -376,9 +375,10 @@
 .. |CALLINDIRECT| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{call\_indirect}}
 .. |TRY| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{try}}
 .. |CATCH| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{catch}}
+.. |CATCHALL| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{catch\_all}}
+.. |DELEGATE| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{delegate}}
 .. |THROW| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{throw}}
 .. |RETHROW| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{rethrow}}
-.. |BRONEXN| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{br\_on\_exn}}
 
 .. |DROP| mathdef:: \xref{syntax/instructions}{syntax-instr-parametric}{\K{drop}}
 .. |SELECT| mathdef:: \xref{syntax/instructions}{syntax-instr-parametric}{\K{select}}
@@ -615,7 +615,7 @@
 .. |Bresulttype| mathdef:: \xref{binary/types}{binary-resulttype}{\B{resulttype}}
 .. |Bfunctype| mathdef:: \xref{binary/types}{binary-functype}{\B{functype}}
 .. |Bglobaltype| mathdef:: \xref{binary/types}{binary-globaltype}{\B{globaltype}}
-.. |Bexntype| mathdef:: \xref{binary/types}{binary-exntype}{\B{exntype}}
+.. |Btagtype| mathdef:: \xref{binary/types}{binary-tagtype}{\B{tagtype}}
 .. |Btabletype| mathdef:: \xref{binary/types}{binary-tabletype}{\B{tabletype}}
 .. |Bmemtype| mathdef:: \xref{binary/types}{binary-memtype}{\B{memtype}}
 .. |Blimits| mathdef:: \xref{binary/types}{binary-limits}{\B{limits}}
@@ -629,7 +629,7 @@
 .. |Bfuncidx| mathdef:: \xref{binary/modules}{binary-funcidx}{\B{funcidx}}
 .. |Btableidx| mathdef:: \xref{binary/modules}{binary-tableidx}{\B{tableidx}}
 .. |Bmemidx| mathdef:: \xref{binary/modules}{binary-memidx}{\B{memidx}}
-.. |Bexnidx| mathdef:: \xref{binary/modules}{binary-exnidx}{\B{exnidx}}
+.. |Btagidx| mathdef:: \xref{binary/modules}{binary-tagidx}{\B{tagidx}}
 .. |Bglobalidx| mathdef:: \xref{binary/modules}{binary-globalidx}{\B{globalidx}}
 .. |Belemidx| mathdef:: \xref{binary/modules}{binary-elemidx}{\B{elemidx}}
 .. |Bdataidx| mathdef:: \xref{binary/modules}{binary-dataidx}{\B{dataidx}}
@@ -650,7 +650,7 @@
 .. |Bcodesec| mathdef:: \xref{binary/modules}{binary-codesec}{\B{codesec}}
 .. |Btablesec| mathdef:: \xref{binary/modules}{binary-tablesec}{\B{tablesec}}
 .. |Bmemsec| mathdef:: \xref{binary/modules}{binary-memsec}{\B{memsec}}
-.. |Bexnsec| mathdef:: \xref{binary/modules}{binary-exnsec}{\B{exnsec}}
+.. |Btagsec| mathdef:: \xref{binary/modules}{binary-tagsec}{\B{tagsec}}
 .. |Bglobalsec| mathdef:: \xref{binary/modules}{binary-globalsec}{\B{globalsec}}
 .. |Bimportsec| mathdef:: \xref{binary/modules}{binary-importsec}{\B{importsec}}
 .. |Bexportsec| mathdef:: \xref{binary/modules}{binary-exportsec}{\B{exportsec}}
@@ -664,7 +664,7 @@
 .. |Bfunc| mathdef:: \xref{binary/modules}{binary-func}{\B{func}}
 .. |Btable| mathdef:: \xref{binary/modules}{binary-table}{\B{table}}
 .. |Bmem| mathdef:: \xref{binary/modules}{binary-mem}{\B{mem}}
-.. |Bexn| mathdef:: \xref{binary/modules}{binary-exn}{\B{exn}}
+.. |Btag| mathdef:: \xref{binary/modules}{binary-tag}{\B{tag}}
 .. |Bglobal| mathdef:: \xref{binary/modules}{binary-global}{\B{global}}
 .. |Bimport| mathdef:: \xref{binary/modules}{binary-import}{\B{import}}
 .. |Bexport| mathdef:: \xref{binary/modules}{binary-export}{\B{export}}
@@ -799,7 +799,7 @@
 .. |Tfuncidx| mathdef:: \xref{text/modules}{text-funcidx}{\T{funcidx}}
 .. |Ttableidx| mathdef:: \xref{text/modules}{text-tableidx}{\T{tableidx}}
 .. |Tmemidx| mathdef:: \xref{text/modules}{text-memidx}{\T{memidx}}
-.. |Texnidx| mathdef:: \xref{text/modules}{text-exnidx}{\T{exnidx}}
+.. |Ttagidx| mathdef:: \xref{text/modules}{text-tagidx}{\T{tagidx}}
 .. |Tglobalidx| mathdef:: \xref{text/modules}{text-globalidx}{\T{globalidx}}
 .. |Telemidx| mathdef:: \xref{text/modules}{text-elemidx}{\T{elemidx}}
 .. |Tdataidx| mathdef:: \xref{text/modules}{text-dataidx}{\T{dataidx}}
@@ -825,7 +825,7 @@
 .. |Tfunc| mathdef:: \xref{text/modules}{text-func}{\T{func}}
 .. |Ttable| mathdef:: \xref{text/modules}{text-table}{\T{table}}
 .. |Tmem| mathdef:: \xref{text/modules}{text-mem}{\T{mem}}
-.. |Texn| mathdef:: \xref{text/modules}{text-exn}{\T{exception}}
+.. |Ttag| mathdef:: \xref{text/modules}{text-tag}{\T{tag}}
 .. |Tglobal| mathdef:: \xref{text/modules}{text-global}{\T{global}}
 .. |Timport| mathdef:: \xref{text/modules}{text-import}{\T{import}}
 .. |Texport| mathdef:: \xref{text/modules}{text-export}{\T{export}}
@@ -871,7 +871,7 @@
 .. |IFUNCS| mathdef:: \xref{text/conventions}{text-context}{\K{funcs}}
 .. |ITABLES| mathdef:: \xref{text/conventions}{text-context}{\K{tables}}
 .. |IMEMS| mathdef:: \xref{text/conventions}{text-context}{\K{mems}}
-.. |IEXNS| mathdef:: \xref{text/conventions}{text-context}{\K{exceptions}}
+.. |ITAGS| mathdef:: \xref{text/conventions}{text-context}{\K{tags}}
 .. |IGLOBALS| mathdef:: \xref{text/conventions}{text-context}{\K{globals}}
 .. |IELEM| mathdef:: \xref{text/conventions}{text-context}{\K{elem}}
 .. |IDATA| mathdef:: \xref{text/conventions}{text-context}{\K{data}}
@@ -894,7 +894,9 @@
 
 .. |ok| mathdef:: \mathrel{\mbox{ok}}
 .. |const| mathdef:: \xref{valid/instructions}{valid-constant}{\mathrel{\mbox{const}}}
+.. |catch| mathdef:: \xref{valid/conventions}{valid-labelkind}{\mathrel{\mbox{catch}}}
 
+.. |labelkind| mathdef:: \xref{valid/conventions}{valid-labelkind}{\mathrel{\X{labelkind}}}
 
 .. Contexts
 
@@ -902,7 +904,7 @@
 .. |CFUNCS| mathdef:: \xref{valid/conventions}{context}{\K{funcs}}
 .. |CTABLES| mathdef:: \xref{valid/conventions}{context}{\K{tables}}
 .. |CMEMS| mathdef:: \xref{valid/conventions}{context}{\K{mems}}
-.. |CEXNS| mathdef:: \xref{valid/conventions}{context}{\K{exceptions}}
+.. |CTAGS| mathdef:: \xref{valid/conventions}{context}{\K{tags}}
 .. |CGLOBALS| mathdef:: \xref{valid/conventions}{context}{\K{globals}}
 .. |CELEMS| mathdef:: \xref{valid/conventions}{context}{\K{elems}}
 .. |CDATAS| mathdef:: \xref{valid/conventions}{context}{\K{datas}}
@@ -919,7 +921,7 @@
 .. |vdashfunctype| mathdef:: \xref{valid/types}{valid-functype}{\vdash}
 .. |vdashtabletype| mathdef:: \xref{valid/types}{valid-tabletype}{\vdash}
 .. |vdashmemtype| mathdef:: \xref{valid/types}{valid-memtype}{\vdash}
-.. |vdashexntype| mathdef:: \xref{valid/types}{valid-exntype}{\vdash}
+.. |vdashtagtype| mathdef:: \xref{valid/types}{valid-tagtype}{\vdash}
 .. |vdashglobaltype| mathdef:: \xref{valid/types}{valid-globaltype}{\vdash}
 .. |vdashexterntype| mathdef:: \xref{valid/types}{valid-externtype}{\vdash}
 
@@ -932,7 +934,7 @@
 .. |vdashfunc| mathdef:: \xref{valid/modules}{valid-func}{\vdash}
 .. |vdashtable| mathdef:: \xref{valid/modules}{valid-table}{\vdash}
 .. |vdashmem| mathdef:: \xref{valid/modules}{valid-mem}{\vdash}
-.. |vdashexn| mathdef:: \xref{valid/modules}{valid-exn}{\vdash}
+.. |vdashtag| mathdef:: \xref{valid/modules}{valid-tag}{\vdash}
 .. |vdashglobal| mathdef:: \xref{valid/modules}{valid-global}{\vdash}
 .. |vdashelem| mathdef:: \xref{valid/modules}{valid-elem}{\vdash}
 .. |vdashelemmode| mathdef:: \xref{valid/modules}{valid-elemmode}{\vdash}
@@ -966,7 +968,7 @@
 .. |allochostfunc| mathdef:: \xref{exec/modules}{alloc-hostfunc}{\F{allochostfunc}}
 .. |alloctable| mathdef:: \xref{exec/modules}{alloc-table}{\F{alloctable}}
 .. |allocmem| mathdef:: \xref{exec/modules}{alloc-mem}{\F{allocmem}}
-.. |allocexn| mathdef:: \xref{exec/modules}{alloc-exn}{\F{allocexn}}
+.. |alloctag| mathdef:: \xref{exec/modules}{alloc-tag}{\F{alloctag}}
 .. |allocglobal| mathdef:: \xref{exec/modules}{alloc-global}{\F{allocglobal}}
 .. |allocelem| mathdef:: \xref{exec/modules}{alloc-elem}{\F{allocelem}}
 .. |allocdata| mathdef:: \xref{exec/modules}{alloc-data}{\F{allocdata}}
@@ -982,7 +984,7 @@
 .. |funcaddr| mathdef:: \xref{exec/runtime}{syntax-funcaddr}{\X{funcaddr}}
 .. |tableaddr| mathdef:: \xref{exec/runtime}{syntax-tableaddr}{\X{tableaddr}}
 .. |memaddr| mathdef:: \xref{exec/runtime}{syntax-memaddr}{\X{memaddr}}
-.. |exnaddr| mathdef:: \xref{exec/runtime}{syntax-exnaddr}{\X{exnaddr}}
+.. |tagaddr| mathdef:: \xref{exec/runtime}{syntax-tagaddr}{\X{tagaddr}}
 .. |globaladdr| mathdef:: \xref{exec/runtime}{syntax-globaladdr}{\X{globaladdr}}
 .. |elemaddr| mathdef:: \xref{exec/runtime}{syntax-elemaddr}{\X{elemaddr}}
 .. |dataaddr| mathdef:: \xref{exec/runtime}{syntax-dataaddr}{\X{dataaddr}}
@@ -1001,7 +1003,7 @@
 .. |MITYPE| mathdef:: \xref{exec/runtime}{syntax-meminst}{\K{type}}
 .. |MIDATA| mathdef:: \xref{exec/runtime}{syntax-meminst}{\K{data}}
 
-.. |EITYPE| mathdef:: \xref{exec/runtime}{syntax-exninst}{\K{type}}
+.. |TAGITYPE| mathdef:: \xref{exec/runtime}{syntax-taginst}{\K{type}}
 
 .. |GITYPE| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\K{type}}
 .. |GIVALUE| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\K{value}}
@@ -1017,14 +1019,14 @@
 .. |EVFUNC| mathdef:: \xref{exec/runtime}{syntax-externval}{\K{func}}
 .. |EVTABLE| mathdef:: \xref{exec/runtime}{syntax-externval}{\K{table}}
 .. |EVMEM| mathdef:: \xref{exec/runtime}{syntax-externval}{\K{mem}}
-.. |EVEXN| mathdef:: \xref{exec/runtime}{syntax-externval}{\K{exception}}
+.. |EVTAG| mathdef:: \xref{exec/runtime}{syntax-externval}{\K{tag}}
 .. |EVGLOBAL| mathdef:: \xref{exec/runtime}{syntax-externval}{\K{global}}
 
 .. |MITYPES| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{types}}
 .. |MIFUNCS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{funcaddrs}}
 .. |MITABLES| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{tableaddrs}}
 .. |MIMEMS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{memaddrs}}
-.. |MIEXNS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{exnaddrs}}
+.. |MITAGS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{tagaddrs}}
 .. |MIGLOBALS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{globaladdrs}}
 .. |MIELEMS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{elemaddrs}}
 .. |MIDATAS| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\K{dataaddrs}}
@@ -1039,7 +1041,7 @@
 .. |funcinst| mathdef:: \xref{exec/runtime}{syntax-funcinst}{\X{funcinst}}
 .. |tableinst| mathdef:: \xref{exec/runtime}{syntax-tableinst}{\X{tableinst}}
 .. |meminst| mathdef:: \xref{exec/runtime}{syntax-meminst}{\X{meminst}}
-.. |exninst| mathdef:: \xref{exec/runtime}{syntax-exninst}{\X{exninst}}
+.. |taginst| mathdef:: \xref{exec/runtime}{syntax-taginst}{\X{taginst}}
 .. |globalinst| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\X{globalinst}}
 .. |eleminst| mathdef:: \xref{exec/runtime}{syntax-eleminst}{\X{eleminst}}
 .. |datainst| mathdef:: \xref{exec/runtime}{syntax-datainst}{\X{datainst}}
@@ -1053,7 +1055,7 @@
 .. |evfuncs| mathdef:: \xref{exec/runtime}{syntax-externval}{\F{funcs}}
 .. |evtables| mathdef:: \xref{exec/runtime}{syntax-externval}{\F{tables}}
 .. |evmems| mathdef:: \xref{exec/runtime}{syntax-externval}{\F{mems}}
-.. |evexns| mathdef:: \xref{exec/runtime}{syntax-externval}{\F{exceptions}}
+.. |evtags| mathdef:: \xref{exec/runtime}{syntax-externval}{\F{tags}}
 .. |evglobals| mathdef:: \xref{exec/runtime}{syntax-externval}{\F{globals}}
 
 
@@ -1062,7 +1064,7 @@
 .. |SFUNCS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{funcs}}
 .. |STABLES| mathdef:: \xref{exec/runtime}{syntax-store}{\K{tables}}
 .. |SMEMS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{mems}}
-.. |SEXNS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{exceptions}}
+.. |STAGS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{tags}}
 .. |SGLOBALS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{globals}}
 .. |SELEMS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{elems}}
 .. |SDATAS| mathdef:: \xref{exec/runtime}{syntax-store}{\K{datas}}
@@ -1085,7 +1087,7 @@
 
 .. |label| mathdef:: \xref{exec/runtime}{syntax-label}{\X{label}}
 .. |frame| mathdef:: \xref{exec/runtime}{syntax-frame}{\X{frame}}
-
+.. |handler| mathdef:: \xref{exec/runtime}{syntax-handler}{\X{handler}}
 
 .. Stack, meta functions
 
@@ -1098,9 +1100,10 @@
 .. |REFEXTERNADDR| mathdef:: \xref{exec/runtime}{syntax-ref.extern}{\K{ref{.}extern}}
 .. |TRAP| mathdef:: \xref{exec/runtime}{syntax-trap}{\K{trap}}
 .. |INVOKE| mathdef:: \xref{exec/runtime}{syntax-invoke}{\K{invoke}}
-.. |REFEXNADDR| mathdef:: \xref{exec/runtime}{syntax-refexnaddr}{\K{ref{.}exn}}
-.. |THROWADDR| mathdef:: \xref{exec/runtime}{syntax-throwaddr}{\K{throw}}
-.. |CATCHN| mathdef:: \xref{exec/runtime}{syntax-catchn}{\K{catch}}
+.. |THROWadm| mathdef:: \xref{exec/runtime}{syntax-throwadm}{\K{throw}}
+.. |CATCHadm| mathdef:: \xref{exec/runtime}{syntax-catchadm}{\K{catch}}
+.. |DELEGATEadm| mathdef:: \xref{exec/runtime}{syntax-delegateadm}{\K{delegate}}
+.. |CAUGHTadm| mathdef:: \xref{exec/runtime}{syntax-caughtadm}{\K{caught}}
 
 
 .. Values & Results, non-terminals
@@ -1120,6 +1123,7 @@
 .. Administrative Instructions, non-terminals
 
 .. |XB| mathdef:: \xref{exec/runtime}{syntax-ctxt-block}{B}
+.. |XC| mathdef:: \xref{exec/runtime}{syntax-ctxt-block}{C}
 .. |XT| mathdef:: \xref{exec/runtime}{syntax-ctxt-throw}{T}
 
 
@@ -1266,7 +1270,7 @@
 .. |vdashfuncinst| mathdef:: \xref{appendix/properties}{valid-funcinst}{\vdash}
 .. |vdashtableinst| mathdef:: \xref{appendix/properties}{valid-tableinst}{\vdash}
 .. |vdashmeminst| mathdef:: \xref{appendix/properties}{valid-meminst}{\vdash}
-.. |vdashexninst| mathdef:: \xref{appendix/properties}{valid-exninst}{\vdash}
+.. |vdashtaginst| mathdef:: \xref{appendix/properties}{valid-taginst}{\vdash}
 .. |vdashglobalinst| mathdef:: \xref{appendix/properties}{valid-globalinst}{\vdash}
 .. |vdasheleminst| mathdef:: \xref{appendix/properties}{valid-eleminst}{\vdash}
 .. |vdashdatainst| mathdef:: \xref{appendix/properties}{valid-datainst}{\vdash}
@@ -1281,7 +1285,7 @@
 .. |vdashfuncinstextends| mathdef:: \xref{appendix/properties}{extend-funcinst}{\vdash}
 .. |vdashtableinstextends| mathdef:: \xref{appendix/properties}{extend-tableinst}{\vdash}
 .. |vdashmeminstextends| mathdef:: \xref{appendix/properties}{extend-meminst}{\vdash}
-.. |vdashexninstextends| mathdef:: \xref{appendix/properties}{extend-exninst}{\vdash}
+.. |vdashtaginstextends| mathdef:: \xref{appendix/properties}{extend-taginst}{\vdash}
 .. |vdashglobalinstextends| mathdef:: \xref{appendix/properties}{extend-globalinst}{\vdash}
 .. |vdasheleminstextends| mathdef:: \xref{appendix/properties}{extend-eleminst}{\vdash}
 .. |vdashdatainstextends| mathdef:: \xref{appendix/properties}{extend-datainst}{\vdash}
@@ -1312,3 +1316,5 @@
 
 .. |error| mathdef:: \xref{appendix/embedding}{embed-error}{\X{error}}
 .. |ERROR| mathdef:: \xref{appendix/embedding}{embed-error}{\K{error}}
+.. |exception| mathdef:: \xref{appendix/embedding}{embed-exception}{\X{exception}}
+.. |EXCEPTION| mathdef:: \xref{appendix/embedding}{embed-exception}{\K{exception}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -909,11 +909,11 @@
 .. |CLABELS| mathdef:: \xref{valid/conventions}{context}{\K{labels}}
 .. |CRETURN| mathdef:: \xref{valid/conventions}{context}{\K{return}}
 .. |CREFS| mathdef:: \xref{valid/conventions}{context}{\K{refs}}
-.. |LCATCH| mathdef:: \xref{valid/conventions}{context}{\mathrel{\K{catch}}}
+.. |LCATCH| mathdef:: \xref{valid/conventions}{context}{\K{catch}}
 
 .. Contexts, non-terminals
 
-.. |labeltype| mathdef:: \xref{valid/conventions}{context}{\mathrel{\X{labeltype}}}
+.. |labeltype| mathdef:: \xref{valid/conventions}{context}{\X{labeltype}}
 
 
 .. Judgments

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -909,11 +909,11 @@
 .. |CLABELS| mathdef:: \xref{valid/conventions}{context}{\K{labels}}
 .. |CRETURN| mathdef:: \xref{valid/conventions}{context}{\K{return}}
 .. |CREFS| mathdef:: \xref{valid/conventions}{context}{\K{refs}}
-.. |LCATCH| mathdef:: \xref{valid/conventions}{valid-labeltype}{\mathrel{\K{catch}}}
+.. |LCATCH| mathdef:: \xref{valid/conventions}{context}{\mathrel{\K{catch}}}
 
 .. Contexts, non-terminals
 
-.. |labeltype| mathdef:: \xref{valid/conventions}{valid-labeltype}{\mathrel{\X{labeltype}}}
+.. |labeltype| mathdef:: \xref{valid/conventions}{context}{\mathrel{\X{labeltype}}}
 
 
 .. Judgments

--- a/document/core/valid/conventions.rst
+++ b/document/core/valid/conventions.rst
@@ -68,7 +68,7 @@ More concretely, contexts are defined as :ref:`records <notation-record>` :math:
         & \CELEMS & \reftype^\ast, \\
         & \CDATAS & {\ok}^\ast, \\
         & \CLOCALS & \valtype^\ast, \\
-        & \CLABELS & \labelkind, \\
+        & \CLABELS & \labelkind^\ast, \\
         & \CRETURN & \resulttype^?, \\
         & \CREFS & \funcidx^\ast ~\} \\
      \end{array}

--- a/document/core/valid/conventions.rst
+++ b/document/core/valid/conventions.rst
@@ -24,9 +24,9 @@ That is, they only formulate the constraints, they do not define an algorithm.
 The skeleton of a sound and complete algorithm for type-checking instruction sequences according to this specification is provided in the :ref:`appendix <algo-valid>`.
 
 
-.. index:: ! context, function type, table type, memory type, tag type, global type, value type, result type, index space, module, function, tag, labelkind
+.. index:: ! context, function type, table type, memory type, tag type, global type, value type, result type, index space, module, function, tag, labeltype
 .. _context:
-.. _labelkind:
+.. _labeltype:
 
 Contexts
 ~~~~~~~~
@@ -43,7 +43,7 @@ which collects relevant information about the surrounding :ref:`module <syntax-m
 * *Element Segments*: the list of element segments declared in the current module, represented by their element type.
 * *Data Segments*: the list of data segments declared in the current module, each represented by an |ok| entry.
 * *Locals*: the list of locals declared in the current function (including parameters), represented by their value type.
-* *Labels*: the stack of labels accessible from the current position, represented by their |labelkind|, which is a result type, possibly prepended by a |catch| entry, if the label is surrounding the instructions inside a |handler|.
+* *Labels*: the stack of labels accessible from the current position, represented by their |labeltype|, which is a result type, possibly prepended by a |LCATCH| entry, if the label is surrounding the instructions inside a |CATCH| or |CATCHALL|.
 * *Return*: the return type of the current function, represented as an optional result type that is absent when no return is allowed, as in free-standing expressions.
 * *References*: the list of :ref:`function indices <syntax-funcidx>` that occur in the module outside functions and can hence be used to form references inside them.
 
@@ -56,7 +56,7 @@ More concretely, contexts are defined as :ref:`records <notation-record>` :math:
 
 .. math::
    \begin{array}{llll}
-   \production{(labelkind)} & \labelkind & ::= & \catch^?~\resulttype^\ast\\
+   \production{(labeltype)} & \labeltype & ::= & \LCATCH^?~\resulttype\\
    \production{(context)} & C &::=&
      \begin{array}[t]{l@{~}ll}
      \{ & \CTYPES & \functype^\ast, \\
@@ -68,7 +68,7 @@ More concretely, contexts are defined as :ref:`records <notation-record>` :math:
         & \CELEMS & \reftype^\ast, \\
         & \CDATAS & {\ok}^\ast, \\
         & \CLOCALS & \valtype^\ast, \\
-        & \CLABELS & \labelkind^\ast, \\
+        & \CLABELS & \labeltype^\ast, \\
         & \CRETURN & \resulttype^?, \\
         & \CREFS & \funcidx^\ast ~\} \\
      \end{array}

--- a/document/core/valid/conventions.rst
+++ b/document/core/valid/conventions.rst
@@ -24,8 +24,9 @@ That is, they only formulate the constraints, they do not define an algorithm.
 The skeleton of a sound and complete algorithm for type-checking instruction sequences according to this specification is provided in the :ref:`appendix <algo-valid>`.
 
 
-.. index:: ! context, function type, table type, memory type, exception type, global type, value type, result type, index space, module, function, exception
+.. index:: ! context, function type, table type, memory type, tag type, global type, value type, result type, index space, module, function, tag, labelkind
 .. _context:
+.. _labelkind:
 
 Contexts
 ~~~~~~~~
@@ -37,12 +38,12 @@ which collects relevant information about the surrounding :ref:`module <syntax-m
 * *Functions*: the list of functions declared in the current module, represented by their function type.
 * *Tables*: the list of tables declared in the current module, represented by their table type.
 * *Memories*: the list of memories declared in the current module, represented by their memory type.
-* *Exceptions*: the list of exceptions declared in the current module, represented by their exception type.
+* *Tags*: the list of tags declared in the current module, represented by their tag type.
 * *Globals*: the list of globals declared in the current module, represented by their global type.
 * *Element Segments*: the list of element segments declared in the current module, represented by their element type.
 * *Data Segments*: the list of data segments declared in the current module, each represented by an |ok| entry.
 * *Locals*: the list of locals declared in the current function (including parameters), represented by their value type.
-* *Labels*: the stack of labels accessible from the current position, represented by their result type.
+* *Labels*: the stack of labels accessible from the current position, represented by their |labelkind|, which is a result type, possibly prepended by a |catch| entry, if the label is surrounding the instructions inside a |handler|.
 * *Return*: the return type of the current function, represented as an optional result type that is absent when no return is allowed, as in free-standing expressions.
 * *References*: the list of :ref:`function indices <syntax-funcidx>` that occur in the module outside functions and can hence be used to form references inside them.
 
@@ -55,18 +56,19 @@ More concretely, contexts are defined as :ref:`records <notation-record>` :math:
 
 .. math::
    \begin{array}{llll}
+   \production{(labelkind)} & \labelkind & ::= & \catch^?~\resulttype^\ast\\
    \production{(context)} & C &::=&
      \begin{array}[t]{l@{~}ll}
      \{ & \CTYPES & \functype^\ast, \\
         & \CFUNCS & \functype^\ast, \\
         & \CTABLES & \tabletype^\ast, \\
         & \CMEMS & \memtype^\ast, \\
-	& \CEXNS & \exntype^\ast, \\
+	& \CTAGS & \tagtype^\ast, \\
         & \CGLOBALS & \globaltype^\ast, \\
         & \CELEMS & \reftype^\ast, \\
         & \CDATAS & {\ok}^\ast, \\
         & \CLOCALS & \valtype^\ast, \\
-        & \CLABELS & \resulttype^\ast, \\
+        & \CLABELS & \labelkind, \\
         & \CRETURN & \resulttype^?, \\
         & \CREFS & \funcidx^\ast ~\} \\
      \end{array}

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1366,7 +1366,8 @@ Control Instructions
 :math:`\TRY~\blocktype~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?~\END`
 ....................................................................................................
 
-**TODO: add prose**
+.. todo::
+   Add prose.
 
 .. math::
    \frac{
@@ -1374,8 +1375,9 @@ Control Instructions
      C \vdashblocktype \blocktype : [t_1^\ast] \to [t_2^\ast]
      \qquad
      C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr_1^\ast : [t_1^\ast] \to [t_2^\ast] \\
-     (C.\CTAGS[x] = [t^\ast]\to[]~\land~C,\CLABELS\,(\catch [t_2^\ast]) \vdashinstrseq \instr_2^\ast : [t^\ast]\to[t_2^\ast])\ast \\
-     (C,\CLABELS\,(\catch~[t_2^\ast]) \vdashinstrseq \instr_3^\ast : []\to[t_2^\ast])^?
+     (C.\CTAGS[x] = [t^\ast]\to[] \\
+     C,\CLABELS\,(\LCATCH [t_2^\ast]) \vdashinstrseq \instr_2^\ast : [t^\ast]\to[t_2^\ast])\ast \\
+     (C,\CLABELS\,(\LCATCH~[t_2^\ast]) \vdashinstrseq \instr_3^\ast : []\to[t_2^\ast])^?
    \end{array}
    }{
    C \vdashinstr \TRY~\blocktype~\instr^\ast (\CATCH~x~\instr_2^\ast)^\ast (\CATCHALL~\instr_3^\ast)^? \END : [t_1^\ast]\to[t_2^\ast]
@@ -1383,7 +1385,7 @@ Control Instructions
 
 
 .. note::
-   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\,(\labelkind^? [t^\ast])` inserts the new label type at index :math:`0`, shifting all others.
+   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\,(\LCATCH^? [t^\ast])` inserts the new label type at index :math:`0`, shifting all others.
 
 
 .. _valid-try-delegate:
@@ -1391,7 +1393,8 @@ Control Instructions
 :math:`\TRY~\blocktype~\instr^\ast~\DELEGATE~l`
 ...............................................
 
-**TODO: add prose**
+.. todo::
+   Add prose.
 
 .. math::
    \frac{
@@ -1433,11 +1436,12 @@ Control Instructions
 :math:`\RETHROW~l`
 ..................
 
-**TODO: add prose**
+.. todo::
+   Add prose.
 
 .. math::
    \frac{
-     C.\CLABELS[l] = \catch~[t^\ast]
+     C.\CLABELS[l] = \LCATCH~[t^\ast]
    }{
      C \vdashinstr \RETHROW~l : [t_1^\ast] \to [t_2^\ast]
    }

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1234,7 +1234,7 @@ Memory Instructions
    }
 
 
-.. index:: control instructions, structured control, label, block, branch, block type, label index, function index, type index, exception index, vector, polymorphism, context
+.. index:: control instructions, structured control, label, block, branch, block type, label index, function index, type index, tag index, vector, polymorphism, context
    pair: validation; instruction
    single: abstract syntax; instruction
 .. _valid-label:
@@ -1361,38 +1361,48 @@ Control Instructions
 
 
 
-.. _valid-try:
+.. _valid-try-catch:
 
-:math:`\TRY~\blocktype~\instr_1^\ast~\CATCH~\instr_2^\ast~\END`
-...............................................................
+:math:`\TRY~\blocktype~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?~\END`
+....................................................................................................
 
-
-* The :ref:`block type <syntax-blocktype>` must be :ref:`valid <valid-blocktype>` as some :ref:`function type <syntax-functype>` :math:`[t_1^\ast] \to [t_2^\ast]`.
-
-* Let :math:`C'` be the same :ref:`context <context>` as :math:`C`, but with the :ref:`result type <syntax-resulttype>` :math:`[t_2^\ast]` prepended to the |CLABELS| vector.
-
-* Under context :math:`C'`,
-  the instruction sequence :math:`\instr_1^\ast` must be :ref:`valid <valid-instr-seq>` with type :math:`[t_1^\ast] \to [t_2^\ast]`.
-
-* Under context :math:`C'`,
-  the instruction sequence :math:`\instr_2^\ast` must be :ref:`valid <valid-instr-seq>` with type :math:`[\EXNREF] \to [t_2^\ast]`.
-
-* Then the compound instruction is valid with type :math:`[t_1^\ast] \to [t_2^\ast]`.
+**TODO: add prose**
 
 .. math::
    \frac{
-     \begin{array}{lll}
-     C \vdashblocktype \blocktype : [t_1^\ast] \to [t_2^\ast] & \qquad & \\
-     C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr_1^\ast : [t_1^\ast] \to [t_2^\ast]
-     & \qquad &
-     C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr_2^\ast : [\EXNREF] \to [t_2^\ast]\\
-     \end{array}
+   \begin{array}{c}
+     C \vdashblocktype \blocktype : [t_1^\ast] \to [t_2^\ast]
+     \qquad
+     C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr_1^\ast : [t_1^\ast] \to [t_2^\ast] \\
+     (C.\CTAGS[x] = [t^\ast]\to[]~\land~C,\CLABELS\,(\catch [t_2^\ast]) \vdashinstrseq \instr_2^\ast : [t^\ast]\to[t_2^\ast])\ast \\
+     (C,\CLABELS\,(\catch~[t_2^\ast]) \vdashinstrseq \instr_3^\ast : []\to[t_2^\ast])^?
+   \end{array}
    }{
-     C \vdashinstr \TRY~\blocktype~\instr_1^\ast~\CATCH~\instr_2^\ast~\END : [t_1^\ast] \to [t_2^\ast]
+   C \vdashinstr \TRY~\blocktype~\instr^\ast (\CATCH~x~\instr_2^\ast)^\ast (\CATCHALL~\instr_3^\ast)^? end : [t_1^\ast]\to[t_2^\ast]
    }
 
+
 .. note::
-   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\,[t_2^\ast]` inserts the new label type at index :math:`0`, shifting all others.
+   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\,(\labelkind^? [t^\ast])` inserts the new label type at index :math:`0`, shifting all others.
+
+
+.. _valid-try-delegate:
+
+:math:`\TRY~\blocktype~\instr^\ast~\DELEGATE~l`
+...............................................
+
+**TODO: add prose**
+
+.. math::
+   \frac{
+     C \vdashblocktype \blocktype : [t_1^\ast] \to [t_2^\ast]
+     \qquad
+     C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr^\ast : [t_1^\ast]\to[t_2^\ast]
+     \qquad
+     |C.\CLABELS| \ge l
+   }{
+   C \vdashinstrseq \TRY~\blocktype~\instr^\ast~\DELEGATE~l : [t_1^\ast]\to[t_2^\ast]
+   }
 
 
 .. _valid-throw:
@@ -1400,15 +1410,15 @@ Control Instructions
 :math:`\THROW~x`
 ................
 
-* The exception :math:`C.\CEXNS[x]` must be defined in the context.
+* The tag :math:`C.\CTAGS[x]` must be defined in the context.
 
-* Let :math:`[t^\ast] \to []` be its :ref:`exception type <syntax-exntype>`.
+* Let :math:`[t^\ast] \to []` be its :ref:`tag type <syntax-tagtype>`.
 
 * Then the instruction is valid with type :math:`[t_1^\ast t^\ast] \to [t_2^\ast]`, for any sequences of  :ref:`value types <syntax-valtype>` :math:`t_1^\ast` and :math:`t_2^\ast`.
 
 .. math::
    \frac{
-     C.\CEXNS[x] = [t^\ast] \to []
+     C.\CTAGS[x] = [t^\ast] \to []
    }{
      C \vdashinstr \THROW~x : [t_1^\ast t^\ast] \to [t_2^\ast]
    }
@@ -1420,50 +1430,21 @@ Control Instructions
 
 .. _valid-rethrow:
 
-:math:`\RETHROW`
-................
+:math:`\RETHROW~l`
+..................
 
-* The instruction is valid with type :math:`[t_1^\ast \EXNREF] \to [t_2^\ast]`, for any sequences of  :ref:`value types <syntax-valtype>` :math:`t_1^\ast` and :math:`t_2^\ast`.
+**TODO: add prose**
 
 .. math::
    \frac{
+     C.\CLABELS[l] = (\catch [t^\ast])
    }{
-     C \vdashinstr \RETHROW : [t_1^\ast \EXNREF] \to [t_2^\ast]
+     C \vdashinstr \RETHROW~l : [t_1^\ast] \to [t_2^\ast]
    }
 
 
 .. note::
    The |RETHROW| instruction is :ref:`stack-polymorphic <polymorphism>`.
-
-
-.. _valid-br_on_exn:
-
-:math:`\BRONEXN~l~x`
-....................
-
-* The label :math:`C.\CLABELS[l]` must be defined in the context.
-
-* The exception :math:`C.\CEXNS[x]` must be defined in the context.
-
-* Let :math:`[t^\ast]` be the :ref:`result type <syntax-resulttype>` :math:`C.\CLABELS[l]`.
-
-* Assert: the exception :math:`C.\CEXNS[x]` is :math:`[t'^\ast]\to[]`.
-
-* The type sequence :math:`t'^\ast` must be the same as the type sequence :math:`t^\ast`.
-
-* Then the instruction is valid with type :math:`[\EXNREF]\to[\EXNREF]`
-
-.. math::
-   \frac{
-     C.\CLABELS[l]=[t^\ast]
-     \qquad
-     C.\CEXNS[x]=[t^\ast]\to[]
-   }{
-     C \vdashinstr \BRONEXN~l~x : [\EXNREF]\to[\EXNREF]
-   }
-
-.. note::
-   The :ref:`label index <syntax-labelidx>` space in the :ref:`context <context>` :math:`C` contains the most recent label first, so that :math:`C.\CLABELS[l]` performs a relative lookup as expected.
 
 
 

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1402,7 +1402,7 @@ Control Instructions
      \qquad
      C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr^\ast : [t_1^\ast]\to[t_2^\ast]
      \qquad
-     |C.\CLABELS| \ge l
+     C.\CLABELS[l] = [t^\ast]
    }{
    C \vdashinstrseq \TRY~\blocktype~\instr^\ast~\DELEGATE~l : [t_1^\ast]\to[t_2^\ast]
    }

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1378,7 +1378,7 @@ Control Instructions
      (C,\CLABELS\,(\catch~[t_2^\ast]) \vdashinstrseq \instr_3^\ast : []\to[t_2^\ast])^?
    \end{array}
    }{
-   C \vdashinstr \TRY~\blocktype~\instr^\ast (\CATCH~x~\instr_2^\ast)^\ast (\CATCHALL~\instr_3^\ast)^? end : [t_1^\ast]\to[t_2^\ast]
+   C \vdashinstr \TRY~\blocktype~\instr^\ast (\CATCH~x~\instr_2^\ast)^\ast (\CATCHALL~\instr_3^\ast)^? \END : [t_1^\ast]\to[t_2^\ast]
    }
 
 
@@ -1437,7 +1437,7 @@ Control Instructions
 
 .. math::
    \frac{
-     C.\CLABELS[l] = (\catch [t^\ast])
+     C.\CLABELS[l] = \catch~[t^\ast]
    }{
      C \vdashinstr \RETHROW~l : [t_1^\ast] \to [t_2^\ast]
    }

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -98,19 +98,19 @@ Memories :math:`\mem` are classified by :ref:`memory types <syntax-memtype>`.
    }
 
 
-.. index:: exception, exception type, function type
-   pair: validation; exception
-   single: abstract syntax; exception
-.. _valid-exn:
+.. index:: tag, tag type, function type, exception tag
+   pair: validation; tag
+   single: abstract syntax; tag
+.. _valid-tag:
 
-Exceptions
-~~~~~~~~~~
+Tags
+~~~~
 
-Exceptions :math:`\exn` are classified by their :ref:`exception type <syntax-exntype>`,
-which contains an index to a :ref:`function type <syntax-functype>` with empty result.
+Tags :math:`\tag` are classified by their :ref:`tag type <syntax-tagtype>`,
+each containing an index to a :ref:`function type <syntax-functype>` with empty result.
 
-:math:`\{ \ETYPE~x \}`
-......................
+:math:`\{ \TAGTYPE~x \}`
+........................
 
 * The type :math:`C.\CTYPES[x]` must be defined in the context.
 
@@ -118,13 +118,13 @@ which contains an index to a :ref:`function type <syntax-functype>` with empty r
 
 * The sequence :math:`t'^\ast` must be empty.
 
-* Then the exception definition is valid with :ref:`exception type <syntax-exntype>` :math:`[t^\ast]\to[]`.
+* Then the tag definition is valid with :ref:`tag type <syntax-tagtype>` :math:`[t^\ast]\to[]`.
 
 .. math::
    \frac{
      C.\CTYPES[x] = [t^\ast] \to []
    }{
-     C \vdashexn \{ \ETYPE~x \} : [t^\ast]\to[]
+     C \vdashtag \{ \TAGTYPE~x \} : [t^\ast]\to[]
    }
 
 
@@ -345,7 +345,7 @@ Start function declarations :math:`\start` are not classified by any type.
    }
 
 
-.. index:: export, name, index, function index, table index, memory index, exception index, global index
+.. index:: export, name, index, function index, table index, memory index, tag index, global index
    pair: validation; export
    single: abstract syntax; export
 .. _valid-exportdesc:
@@ -417,18 +417,18 @@ Exports :math:`\export` and export descriptions :math:`\exportdesc` are classifi
    }
 
 
-:math:`\EDEXN~x`
+:math:`\EDTAG~x`
 ................
 
-* The exception :math:`C.\CEXNS[x]` must be defined in the context.
+* The tag :math:`C.\CTAGS[x]` must be defined in the context.
 
-* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETEXN~C.\CEXNS[x]`.
+* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETTAG~C.\CTAGS[x]`.
 
 .. math::
    \frac{
-     C.\CEXNS[x] = \exntype
+     C.\CTAGS[x] = \tagtype
    }{
-     C \vdashexportdesc \EDEXN~x : \ETEXN~\exntype
+     C \vdashexportdesc \EDTAG~x : \ETTAG~\tagtype
    }
 
 
@@ -447,7 +447,7 @@ Exports :math:`\export` and export descriptions :math:`\exportdesc` are classifi
    }
 
 
-.. index:: import, name, function type, table type, memory type, exception type, global type
+.. index:: import, name, function type, table type, memory type, tag type, global type
    pair: validation; import
    single: abstract syntax; import
 .. _valid-importdesc:
@@ -521,22 +521,22 @@ Imports :math:`\import` and import descriptions :math:`\importdesc` are classifi
    }
 
 
-:math:`\IDEXN~\exn`
+:math:`\IDTAG~\tag`
 ...................
 
-* Let :math:`\{ \ETYPE~x \}` be the exception :math:`\exn`.
+* Let :math:`\{ \TAGTYPE~x \}` be the tag :math:`\tag`.
 
 * The type :math:`C.\CTYPES[x]` must be defined in the context.
 
-* The :ref:`exception type <syntax-exntype>` :math:`C.\CTYPES[x]` must be a :ref:`valid exception type <valid-exntype>`.
+* The :ref:`tag type <syntax-tagtype>` :math:`C.\CTYPES[x]` must be a :ref:`valid tag type <valid-tagtype>`.
 
-* Then the import description is valid with type :math:`\ETEXN~C.\CTYPES[x]`.
+* Then the import description is valid with type :math:`\ETTAG~C.\CTYPES[x]`.
 
 .. math::
    \frac{
-     \vdashexntype C.\CTYPES[x] \ok
+     \vdashtagtype C.\CTYPES[x] \ok
    }{
-     C \vdashimportdesc \IDEXN~\{ \ETYPE~x \} : \ETEXN~C.\CTYPES[x]
+     C \vdashimportdesc \IDTAG~\{ \TAGTYPE~x \} : \ETTAG~C.\CTYPES[x]
    }
 
 
@@ -556,7 +556,7 @@ Imports :math:`\import` and import descriptions :math:`\importdesc` are classifi
    }
 
 
-.. index:: module, type definition, function type, function, table, memory, exception, global, element, data, start function, import, export, context
+.. index:: module, type definition, function type, function, table, memory, tag, global, element, data, start function, import, export, context
    pair: validation; module
    single: abstract syntax; module
 .. _valid-module:
@@ -586,8 +586,8 @@ Instead, the context :math:`C` for validation of the module's content is constru
   * :math:`C.\CMEMS` is :math:`\etmems(\X{it}^\ast)` concatenated with :math:`\X{mt}^\ast`,
     with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`memory types <syntax-memtype>` :math:`\X{mt}^\ast` as determined below,
 
-  * :math:`C.\CEXNS` is :math:`\etexns(\X{it}^\ast)` concatenated with :math:`\X{exnt}^\ast`,
-    with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`exception types <syntax-exntype>` :math:`\X{exnt}^\ast` as determined below,
+  * :math:`C.\CTAGS` is :math:`\ettags(\X{it}^\ast)` concatenated with :math:`\X{tagt}^\ast`,
+    with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`tag types <syntax-tagtype>` :math:`\X{tagt}^\ast` as determined below,
 
   * :math:`C.\CGLOBALS` is :math:`\etglobals(\X{it}^\ast)` concatenated with :math:`\X{gt}^\ast`,
     with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`global types <syntax-globaltype>` :math:`\X{gt}^\ast` as determined below,
@@ -612,7 +612,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
 
   * :math:`C'.\CREFS` is the same as :math:`C.\CREFS`,
 
-  * :math:`C'.\CEXNS` is the same as :math:`C.\CEXNS`,
+  * :math:`C'.\CTAGS` is the same as :math:`C.\CTAGS`,
 
   * all other fields are empty.
 
@@ -630,8 +630,8 @@ Instead, the context :math:`C` for validation of the module's content is constru
   * For each :math:`\mem_i` in :math:`\module.\MMEMS`,
     the definition :math:`\mem_i` must be :ref:`valid <valid-mem>` with a :ref:`memory type <syntax-memtype>` :math:`\X{mt}_i`.
 
-  * For each :math:`\exn_i` in :math:`\module.\MEXNS`,
-    the definition :math:`\exn_i` must be :ref:`valid <valid-exn>` with an :ref:`exception type <syntax-exntype>` :math:`\X{exnt}_i`.
+  * For each :math:`\tag_i` in :math:`\module.\MTAGS`,
+    the definition :math:`\tag_i` must be :ref:`valid <valid-tag>` with an :ref:`tag type <syntax-tagtype>` :math:`\X{tagt}_i`.
 
   * For each :math:`\global_i` in :math:`\module.\MGLOBALS`:
 
@@ -663,7 +663,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
 
 * Let :math:`\X{mt}^\ast` be the concatenation of the internal :ref:`memory types <syntax-memtype>` :math:`\X{mt}_i`, in index order.
 
-* Let :math:`\X{exnt}^\ast` be the concatenation of the internal :ref:`exception types <syntax-exntype>` :math:`\X{exnt}_i`, in index order.
+* Let :math:`\X{tagt}^\ast` be the concatenation of the internal :ref:`tag types <syntax-tagtype>` :math:`\X{tagt}_i`, in index order.
 
 * Let :math:`\X{gt}^\ast` be the concatenation of the internal :ref:`global types <syntax-globaltype>` :math:`\X{gt}_i`, in index order.
 
@@ -686,7 +686,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \quad
      (C \vdashmem \mem : \X{mt})^\ast
      \quad
-     (C \vdashexn \exn : \X{exnt})^\ast
+     (C \vdashtag \tag : \X{tagt})^\ast
      \\
      (C' \vdashglobal \global : \X{gt})^\ast
      \\
@@ -706,16 +706,16 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \qquad
      \X{imt}^\ast = \etmems(\X{it}^\ast)
      \\
-     \X{iet}^\ast = \etexns(\X{it}^\ast)
+     \X{itagt}^\ast = \ettags(\X{it}^\ast)
      \qquad
      \X{igt}^\ast = \etglobals(\X{it}^\ast)
      \\
      x^\ast = \freefuncidx(\module \with \MFUNCS = \epsilon \with \MSTART = \epsilon)
      \\
-     C = \{ \CTYPES~\type^\ast, \CFUNCS~\X{ift}^\ast\,\X{ft}^\ast, \CTABLES~\X{itt}^\ast\,\X{tt}^\ast, \CMEMS~\X{imt}^\ast\,\X{mt}^\ast, \CEXNS~\X{iet}^\ast\,\X{exnt}^\ast,\\
+     C = \{ \CTYPES~\type^\ast, \CFUNCS~\X{ift}^\ast\,\X{ft}^\ast, \CTABLES~\X{itt}^\ast\,\X{tt}^\ast, \CMEMS~\X{imt}^\ast\,\X{mt}^\ast, \CTAGS~\X{itagt}^\ast\,\X{tagt}^\ast,\\
         \CGLOBALS~\X{igt}^\ast\,\X{gt}^\ast, \CELEMS~\X{rt}^\ast, \CDATAS~{\ok}^n, \CREFS~x^\ast \}
      \\
-     C' = \{ \CGLOBALS~\X{igt}^\ast, \CFUNCS~(C.\CFUNCS), \CREFS~(C.\CREFS), \CEXNS~(C.\CEXNS) \}
+     C' = \{ \CGLOBALS~\X{igt}^\ast, \CFUNCS~(C.\CFUNCS), \CREFS~(C.\CREFS), \CTAGS~(C.\CTAGS) \}
      \\
      |C.\CMEMS| \leq 1
      \qquad
@@ -727,7 +727,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
          \MFUNCS~\func^\ast,
          \MTABLES~\table^\ast,
          \MMEMS~\mem^\ast,
-         \MEXNS~\exn^\ast,
+         \MTAGS~\tag^\ast,
          \MGLOBALS~\global^\ast, \\
          \MELEMS~\elem^\ast,
          \MDATAS~\data^n,

--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -165,9 +165,8 @@ Tag Types
 
 .. math::
    \frac{
-     \vdashfunctype [t^n] \to [] \ok
    }{
-     \vdashtagtype [t^n] \to [] \ok
+     \vdashtagtype [t^\ast] \to [] \ok
    }
 
 

--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -2,7 +2,7 @@ Types
 -----
 
 Most :ref:`types <syntax-type>` are universally valid.
-However, restrictions apply to :ref:`exception types <syntax-exntype>` and to :ref:`limits <syntax-limits>`, which must be checked during validation.
+However, restrictions apply to :ref:`exception tag types <syntax-tagtype>` and to :ref:`limits <syntax-limits>`, which must be checked during validation.
 Moreover, :ref:`block types <syntax-blocktype>` are converted to plain :ref:`function types <syntax-functype>` for ease of processing.
 
 
@@ -146,13 +146,13 @@ Memory Types
    }
 
 
-.. index:: exception type, function type
-   pair: validation; exception type
-   single: abstract syntax; exception type
-.. _valid-exntype:
+.. index:: tag type, function type, exception tag
+   pair: validation; tag type
+   single: abstract syntax; tag type
+.. _valid-tagtype:
 
-Exception Types
-~~~~~~~~~~~~~~~
+Tag Types
+~~~~~~~~~
 
 :math:`[t_1^n] \to [t_2^m]`
 ...........................
@@ -161,13 +161,13 @@ Exception Types
 
 * The type sequence :math:`t_2^m` must be empty.
 
-* Then the exception type is valid.
+* Then the tag type is valid.
 
 .. math::
    \frac{
      \vdashfunctype [t^n] \to [] \ok
    }{
-     \vdashexntype [t^n] \to [] \ok
+     \vdashtagtype [t^n] \to [] \ok
    }
 
 
@@ -241,18 +241,18 @@ External Types
      \vdashexterntype \ETMEM~\memtype \ok
    }
 
-:math:`\ETEXN~\exntype`
+:math:`\ETTAG~\tagtype`
 .......................
 
-* The :ref:`exception type <syntax-exntype>` :math:`\exntype` must be :ref:`valid <valid-exntype>`.
+* The :ref:`tag type <syntax-tagtype>` :math:`\tagtype` must be :ref:`valid <valid-tagtype>`.
 
 * Then the external type is valid.
 
 .. math::
    \frac{
-     \vdashexntype \exntype \ok
+     \vdashtagtype \tagtype \ok
    }{
-     \vdashexterntype \ETEXN~\exntype \ok
+     \vdashexterntype \ETTAG~\tagtype \ok
    }
 
 :math:`\ETGLOBAL~\globaltype`
@@ -377,20 +377,20 @@ An :ref:`external type <syntax-externtype>` :math:`\ETMEM~\limits_1` matches :ma
    }
 
 
-.. index:: exception type, value type
-.. _match-exntype:
+.. index:: tag type, value type
+.. _match-tagtype:
 
-Exceptions
-..........
+Tags
+....
 
-An :ref:`external type <syntax-externtype>` :math:`\ETEXN~\exntype_1` matches :math:`\ETEXN~\exntype_2`  if and only if:
+An :ref:`external type <syntax-externtype>` :math:`\ETTAG~\tagtype_1` matches :math:`\ETTAG~\tagtype_2`  if and only if:
 
-* Both :math:`\ETEXN~\exntype_1` and :math:`\ETEXN~\exntype_2` are the same.
+* Both :math:`\ETTAG~\tagtype_1` and :math:`\ETTAG~\tagtype_2` are the same.
 
 .. math::
    \frac{
    }{
-     \vdashexterntypematch \ETEXN~\exntype \matchesexterntype \ETEXN~\exntype
+     \vdashexterntypematch \ETTAG~\tagtype \matchesexterntype \ETTAG~\tagtype
    }
 
 


### PR DESCRIPTION
Updates formal spec to (partially) implement the 3rd EH proposal.

In particular:

- exnref is removed from reference types
- REFEXNADDR is removed from administrative instructions
- exn and exception are renamed to tag (also when part of a word/macro)
- renamed EITYPE to TAGITYPE, ETYPE to TAGTYPE,
- changed variable names for tags from "et" to "tt" or "tagt", "iet" to "itagt"
- adjusted indexing where needed
- CATCHN is renamed to CATCHadm and its syntax and rules are adjusted
- added CAUGHTadm and DELEGATEadm, both with syntax and rules
- adjusted syntax and rules for TRY-CATCH, using \catchtype in binary and syntax, in order to describe TRY-CATCH compactly
- added syntax and rules for TRY-DELEGATE
- adjusted syntax and rules for RETHROW
- removed dependencies "bulk instructions" and "reference types" from Release
- adjusted/added validation example of control frame with opcode catch/catch_all resp.
- adjusted "Folded Instructions" for TRY-CATCH (didn't add folded TRY-DELEGATE)
- in several places added or adjusted prose, or added TODO items to add prose later

In particular there are still the following items marked as
TODO:

[] to add prose for typing rule of DELEGATEadm
[] to add prose for execution rules of TRY-CATCH, TRY-DELEGATE, and RETHROW
[] to finish prose for "Throwing an exception" (exec/instructions.rst)
[] to add EXCEPTION result value, signifying throwing an exception to the embedder
[] to adjust block contexts by adding CATCHadm, DELEGATEadm, and CAUGHTadm
[] to change labels to include the label type "catch" (in section "Contexts")
[] to add prose for validation rules of TRY-DELEGATE and RETHROW