### PR TITLE
Cherry-pick CI update from upstream spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -78,7 +78,7 @@ jobs:
           name: core-api-rendered
           path: _output/core
       - name: Publish HTML to GitHub Pages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           publish_dir: ./_output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - run: pip install bikeshed && bikeshed update
       - run: pip install six
       - run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-      - run: pip install sphinx==3.5.2
+      - run: pip install sphinx==3.5.4
       - run: cd document/core && make all
       - uses: actions/upload-artifact@v2
         with:

--- a/document/README.md
+++ b/document/README.md
@@ -42,7 +42,7 @@ pipenv shell
 Install Python dependencies:
 
 ```
-pipenv install Sphinx==3.5.2
+pipenv install Sphinx==3.5.4
 ```
 
 ### Checking out the repository


### PR DESCRIPTION
This PR cherry-picks a commit from upstream that re-enables CI now that the primary branch has changed to `main`.