### PR TITLE
Fix minor merge issue in tests

### DIFF
--- a/test/core/br_table.wast
+++ b/test/core/br_table.wast
@@ -1602,20 +1602,6 @@
 
 
 (assert_invalid
-  (module (func $meet-bottom (param i32) (result externref)
-    (block $l1 (result externref)
-      (drop
-        (block $l2 (result i32)
-          (br_table $l2 $l1 $l2 (ref.null extern) (local.get 0))
-        )
-      )
-      (ref.null extern)
-    )
-  ))
-  "type mismatch"
-)
-
-(assert_invalid
   (module (func $unbound-label
     (block (br_table 2 1 (i32.const 1)))
   ))

--- a/test/core/select.wast
+++ b/test/core/select.wast
@@ -272,7 +272,7 @@
 (assert_return (invoke "as-br_table-last" (i32.const 1)) (i32.const 2))
 
 (assert_return (invoke "as-call_indirect-first" (i32.const 0)) (i32.const 3))
-;;(assert_return (invoke "as-call_indirect-first" (i32.const 1)) (i32.const 2))
+(assert_return (invoke "as-call_indirect-first" (i32.const 1)) (i32.const 2))
 (assert_return (invoke "as-call_indirect-mid" (i32.const 0)) (i32.const 1))
 (assert_return (invoke "as-call_indirect-mid" (i32.const 1)) (i32.const 1))
 (assert_trap (invoke "as-call_indirect-last" (i32.const 0)) "undefined element")


### PR DESCRIPTION
The `br_table.wast` and `select.wast` tests don't have any additions for exception handling, but get picked up in the testsuite update script because they differ from the upstream spec repo.

This appears to be due to a merge issue. For example, the `br_table.wast` deletion comes from https://github.com/WebAssembly/spec/pull/1329

This PR restores these files to the upstream versions.