### PR TITLE
Potential typo in import section for binary format

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -175,7 +175,7 @@ It decodes into a vector of :ref:`imports <syntax-import>` that represent the |M
      \hex{01}~~\X{tt}{:}\Btabletype &\Rightarrow& \IDTABLE~\X{tt} \\ &&|&
      \hex{02}~~\X{mt}{:}\Bmemtype &\Rightarrow& \IDMEM~\X{mt} \\ &&|&
      \hex{03}~~\X{gt}{:}\Bglobaltype &\Rightarrow& \IDGLOBAL~\X{gt} \\ &&|&
-     \hex{04}~~\X{et}{:}\Bexn &\Rightarrow& \IDEXN~\X{et} \\
+     \hex{04}~~\X{et}{:}\Bexntype &\Rightarrow& \IDEXN~\X{et} \\
    \end{array}
 
 


### PR DESCRIPTION
I believe this line of the spec should be referring to the type itself, not the section? PTAL @ioannad 