### PR TITLE
Small fixes on formal spec overview/examples

### DIFF
--- a/proposals/exception-handling/Exceptions-formal-overview.md
+++ b/proposals/exception-handling/Exceptions-formal-overview.md
@@ -185,7 +185,7 @@ label_m{} B^l[ delegate{l} T[val^n (throw a)] end ] end
   ↪ val^n (throw a)
 ```
 
-Note that the last reduction step above is similar to the reduction of `br l` [1](https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-control-mathsf-br-l), if we look at the entire `delegate{l}...end` as the `br l`, but also doing a throw after it breaks.
+Note that the last reduction step above is similar to the reduction of `br l` [1], if we look at the entire `delegate{l}...end` as the `br l`, but also doing a throw after it breaks.
 
 There is a subtle difference though. The instruction `br l` searches for the `l+1`th surrounding block and breaks out after that block. Because `delegate{l}` is always wrapped in its own `label_n{} ... end` [2], with the same lookup as for `br l` we end up breaking inside the `l+1`th surrounding block, and throwing there. So if that `l+1`th surrounding block is a try, we end up throwing in its "try code", and thus correctly getting delegated to that try's catches.
 

--- a/proposals/exception-handling/Exceptions-formal-overview.md
+++ b/proposals/exception-handling/Exceptions-formal-overview.md
@@ -189,7 +189,7 @@ Note that the last reduction step above is similar to the reduction of `br l` [1
 
 There is a subtle difference though. The instruction `br l` searches for the `l+1`th surrounding block and breaks out after that block. Because `delegate{l}` is always wrapped in its own `label_n{} ... end` [2], with the same lookup as for `br l` we end up breaking inside the `l+1`th surrounding block, and throwing there. So if that `l+1`th surrounding block is a try, we end up throwing in its "try code", and thus correctly getting delegated to that try's catches.
 
-- [1] [The execution step for `br l`](https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-control-mathsf-br-l)  
+- [1] [The execution step for `br l`](https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-control-mathsf-br-l)
 - [2] The label that always wraps `delegate{l}...end` can be thought of as "level -1" and cannot be referred to by the delegate's label index `l`.
 
 ### Typing Rules for Administrative Instructions


### PR DESCRIPTION
- Removes a link next to `[1]`. The link is also in the footnote so it's
  not strictly necessary, and adding a link right next to `[1]` makes
  `[]` disappear, so it appears as just `1`, which isn't probably what
  the author intended.
- Both of `throw/catch x` and `throw/catch $x` are being used. Unified
  them into `throw/catch $x`.
- Fixed a location of `$label2` in a test.
- Removes `_m` from `catch` and `caught` administrative instructions in
  Exceptions-formal-examples.md. They were only removed in the overview.
- Removes trailing whitespaces