### PR TITLE
Formal overview address latest review

### DIFF
--- a/proposals/exception-handling/Exceptions-formal-overview.md
+++ b/proposals/exception-handling/Exceptions-formal-overview.md
@@ -83,10 +83,12 @@ C ⊢ try bt instr1* (catch x instr2*)* (catch_all instr3*)? end : [t1*]→[t2*]
 
 C ⊢ bt : [t1*]→[t2*]
 C, labels [t2*] ⊢ instr* : [t1*]→[t2*]
-|C.labels| ≥ l
+C.labels[l] = [t0*]
 -------------------------------------------
 C ⊢ try bt instr* delegate l : [t1*]→[t2*]
 ```
+
+Note that `try ... delegate 0` may appear without any explicitly surrounding block, in which case the label 0 refers to the label of the frame. Currently it is not allowed to refer to a label higher than the one of the frame.
 
 ## Execution (Reduction)
 
@@ -209,7 +211,7 @@ S;C, labels [t2*] ⊢ instr1* : []→[t2*]
 S;C, labels [t2*] ⊢ catch{a? instr2*}* instr1* end : []→[t2*]
 
 S;C, labels [t*] ⊢ instr* : []→[t*]
-|C.labels| ≥ l
+C.labels[l+1] = [t0*]
 ------------------------------------------------------
 S;C, labels [t*] ⊢ delegate{l} instr* end : []→[t*]
 

--- a/proposals/exception-handling/Exceptions-formal-overview.md
+++ b/proposals/exception-handling/Exceptions-formal-overview.md
@@ -83,7 +83,7 @@ C ⊢ try bt instr1* (catch x instr2*)* (catch_all instr3*)? end : [t1*]→[t2*]
 
 C ⊢ bt : [t1*]→[t2*]
 C, labels [t2*] ⊢ instr* : [t1*]→[t2*]
-C.labels[l] = [t*]
+|C.labels| ≥ l
 -------------------------------------------
 C ⊢ try bt instr* delegate l : [t1*]→[t2*]
 ```
@@ -209,7 +209,7 @@ S;C, labels [t2*] ⊢ instr1* : []→[t2*]
 S;C, labels [t2*] ⊢ catch{a? instr2*}* instr1* end : []→[t2*]
 
 S;C, labels [t*] ⊢ instr* : []→[t*]
-C.labels[l] = [t0*]
+|C.labels| ≥ l
 ------------------------------------------------------
 S;C, labels [t*] ⊢ delegate{l} instr* end : []→[t*]
 

--- a/proposals/exception-handling/Exceptions-formal-overview.md
+++ b/proposals/exception-handling/Exceptions-formal-overview.md
@@ -210,10 +210,10 @@ S;C, labels [t2*] ⊢ instr1* : []→[t2*]
 -----------------------------------------------------------
 S;C, labels [t2*] ⊢ catch{a? instr2*}* instr1* end : []→[t2*]
 
-S;C, labels [t*] ⊢ instr* : []→[t*]
+S;C ⊢ instr* : []→[t*]
 C.labels[l+1] = [t0*]
 ------------------------------------------------------
-S;C, labels [t*] ⊢ delegate{l} instr* end : []→[t*]
+S;C ⊢ delegate{l} instr* end : []→[t*]
 
 S ⊢ tag a : tag [t0*]→[]
 (val:t0)*


### PR DESCRIPTION
This PR attempts to address @rossberg 's  last review on merged PR#143, and makes some extra changes for readability, and documentation.

@rossberg @aheejin 

Continuing here the [last discussion](https://github.com/WebAssembly/exception-handling/pull/143/files#r759907998) from the merged PR #143, because that PR is closed and difficult to follow.

The change to remove the +1 from the typing rule of the administrative delegate (will call it adm.delegate) was related to the decision to allow a plain `(try bt instr* delegate 0)` in the function body. It seems I forgot to update the typing rule for try-delegate itself to be in accord with that decision. 

So I think the correct rule for try-delegate should be the following (previously the 3rd premise was `C.labels[l] = [t'*]`, which was equivalent to `|C.labels| > l`).

```
C ⊢ bt : [t1*]→[t2*]
C, labels [t2*] ⊢ instr* : [t1*]→[t2*]
|C.labels| ≥ l
-------------------------------------------
C ⊢ try bt instr* delegate l : [t1*]→[t2*]
```

This way, a context with an empty labels vector can validate this even for `l=0`.

If we now rewrite the typing rule of adm.delegate in the same style it becomes:

```
S;C, labels [t*] ⊢ instr* : []→[t*]
|C.labels| ≥ l
-----------------------------------------------------
S;C, labels [t*] ⊢ delegate{l} instr* end : []→[t*]
```

So perhaps there was no +1 missing from this rule, but a label too many in the typing rule of try.delegate?

**Question**
1. Do you think this new rule for `try-delegate` addresses your concerns with regard to type preservation?
2. Would it be better (and perhaps equivalent?) to write the typing rule for adm.delegate as follows?

```
S;C ⊢ instr* : []→[t*]
|C.labels| > l
-----------------------------------------------------
S;C ⊢ delegate{l} instr* end : []→[t*]
```
