### PR TITLE
Change tag name subsection code to 11

### DIFF
--- a/document/core/appendix/custom.rst
+++ b/document/core/appendix/custom.rst
@@ -60,6 +60,7 @@ Id  Subsection
  0  :ref:`module name <binary-modulenamesec>`
  1  :ref:`function names <binary-funcnamesec>`    
  2  :ref:`local names <binary-localnamesec>`
+11  :ref:`tag names <binary-tagnamesec>`
 ==  ===========================================
 
 Each subsection may occur at most once, and in order of increasing id.

--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -633,7 +633,7 @@ follows:
 | --------- | ---- | ----------- |
 | [Function](#function-names) | `1` | Assigns names to functions |
 | [Local](#local-names) | `2` | Assigns names to locals in functions |
-| [Tag](#tag-names) | `3` | Assigns names to tag types |
+| [Tag](#tag-names) | `11` | Assigns names to tags |
 
 ###### Tag names
 


### PR DESCRIPTION
Name subsectsection [code 3~9](https://github.com/WebAssembly/extended-name-section/blob/main/proposals/extended-name-section/Overview.md#name-subsections) are taken by the extended name section
proposal, and [code 10](https://github.com/WebAssembly/gc/issues/193) is taken by the GC proposal.

Fixes #211.