### PR TITLE
[js-api] Specify maximum number of tags

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1423,6 +1423,7 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum number of imports declared in a module is 100000.</li>
 <li>The maximum number of exports declared in a module is 100000.</li>
 <li>The maximum number of globals defined in a module is 1000000.</li>
+<li>The maximum number of tags defined in a module is 1000000.</li>
 <li>The maximum number of data segments defined in a module is 100000.</li>
 
 <li>The maximum number of tables, including declared or imported tables, is 100000.</li>


### PR DESCRIPTION
It is implemented as 1000000 in both V8 and Firefox.
V8: https://github.com/v8/v8/blob/64aeabbc95576892b61d3e99e60ea74bbf734f80/src/wasm/wasm-limits.h#L36
Firefox: https://github.com/mozilla/gecko-dev/blob/7b9d23ece4835bf355e5195f30fef942d376a1c7/js/src/wasm/WasmConstants.h#L1087

Fixes #212.

cc @eqrion 