### PR TITLE
Modified the throw context example with concrete types but not concrete values.

### DIFF
--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -732,23 +732,24 @@ Throw contexts allow matching the program context around a throw instruction up 
 .. note::
    For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.
 
-   Assume that :math:`\expand_F(bt) = [t1^n] \to [t2^m]`, for some :math:`n > m` such that :math:`t1^n[(n-m):n] = t2^m`,
-   and that the tag address `a` of :math:`x` corresponds to the tag type :math:`[t2^m] \to []`.
+   Assume that :math:`\expand_F(bt) = [i32 f32 i64] \to [f32 i64]`,
+   and that the tag address `a` of :math:`x` corresponds to the tag type :math:`[f32 i64] \to []`.
+   Let :math:`\val_{i32}`, :math:`\val_{f32}`, and :math:`\val_{i64}` be values of type |i32|, |f32|, and |i64| respectively.
 
    .. math::
       \begin{array}{ll}
-      & \hspace{-5ex} S;~F;~\val^n~(\TRY~\X{bt}~(\THROW~x)~\CATCH~x~\RETURN~\END) \\
-      \stepto & S;~F;~\LABEL_m\{\} (\CATCHadm\{a~\RETURN\}~\val^n~(\THROW~x)~\END)~\END \\
+      & \hspace{-5ex} F;~\val_{i32}~\val_{f32}~\val_{i64}~(\TRY~\X{bt}~(\THROW~x)~\CATCH~x~\END) \\
+      \stepto & F;~\LABEL_2\{\} (\CATCHadm\{a~\epsilon}~\val_{i32}~\val_{f32}~\val_{i64}~(\THROW~x)~\END)~\END \\
       \end{array}
 
-   We denote :math:`\val^n = \val^{n-m} \val^m`.
    :ref:`Handling the thrown exception <exec-throwadm>` with tag address :math:`a` in the throw context
-   :math:`T=[val^{n-m}\_]`, with the exception handler :math:`H=\CATCHadm\{a~\RETURN\}` gives:
+   :math:`T=[val_{i32}\_]`, with the exception handler :math:`H=\CATCHadm\{a~\epsilon\}` gives:
 
    .. math::
       \begin{array}{lll}
-      \stepto & S;~F;~\LABEL_m\{\}~(\CAUGHTadm\{a~\val^m\}~\val^m~\RETURN~\END)~\END & \hspace{9ex}\ \\
-      \stepto & \val^m & \\
+      \stepto & F;~\LABEL_2\{\}~(\CAUGHTadm\{a~\val_{f32}~\val_{i64}\}~\val_{f32}~\val_{i64}~\END)~\END & \hspace{9ex}\ \\
+      \stepto & F;~\LABEL_2\{\}~\val_{f32}~\val_{i64}~\END & \hspace{9ex}\ \\
+      \stepto & \val_{f32}~\val_{i64} & \\
       \end{array}
 
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -752,15 +752,12 @@ If no exception :ref:`handler that catches the exception <syntax-handler>` is fo
       \end{array}
 
 
-   When a throw of the form :math:`val^m (\THROWadm~a)` occurs, search for the maximal surrounding throw context :math:`T` is performed,
-   which means any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`val^m (\THROWadm~a)` are popped,
+   When a throw of the form :math:`\val^m (\THROWadm~a)` occurs, search for the maximal surrounding throw context :math:`T` is performed,
+   which means any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`\val^m (\THROWadm~a)` are popped,
    until a :ref:`handler <syntax-handler>` for the exception is found.
    Then a new |CAUGHTadm| instruction, containing the tag address :math:`a` and the values :math:`\val^m`, is pushed onto the stack.
 
-   If no exception :ref:`handler that catches the exception <syntax-handler>` is found, the computation :ref:`results <syntax-result>` in an uncaught exception result value, which contains the exception's entire throw context.
-
    In this particular case, the exception is caught by the exception handler :math:`H` and its values are returned.
-
 
 
 .. index:: ! configuration, ! thread, store, frame, instruction, module instruction
@@ -800,7 +797,7 @@ Finally, the following definition of *evaluation context* and associated structu
    \begin{array}{llll}
    \production{(evaluation contexts)} & E &::=&
      [\_] ~|~
-     val^\ast~E~\instr^\ast ~|~
+     \val^\ast~E~\instr^\ast ~|~
      \LABEL_n\{\instr^\ast\}~E~\END \\
    \end{array}
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -730,10 +730,10 @@ Throw contexts allow matching the program context around a throw instruction up 
    |CAUGHTadm| blocks do not represent active handlers. Instead, they delimit the continuation of a handler that has already been selected. Their sole purpose is to record the exception that has been caught, such that |RETHROW| can access it inside such a block.
 
 .. note::
-   For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.
+   For example, catching a simple :ref:`throw <syntax-throw>` in a :ref:`try block <syntax-try-catch>` would be as follows.
 
    Assume that :math:`\expand_F(bt) = [\I32~\F32~\I64] \to [\F32~\I64]`,
-   and that the tag address `a` of :math:`x` corresponds to the tag type :math:`[\F32~\I64] \to []`.
+   and that the tag address `a` of :math:`x` has tag type :math:`[\F32~\I64] \to []`.
    Let :math:`\val_{i32}`, :math:`\val_{f32}`, and :math:`\val_{i64}` be values of type |I32|, |F32|, and |I64| respectively.
 
    .. math::
@@ -760,7 +760,7 @@ Throw contexts allow matching the program context around a throw instruction up 
    We then append the values :math:`\val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
 
    In other words, a thrown exception is caught when it's the continuation of a throw context in a catching try block,
-   i.e., it's inside a catching try block, which is the innermost with respect to the throw.
+   i.e., it is inside a catching try block, which is the innermost with respect to the throw.
 
    In this particular case, the exception is caught by the exception handler :math:`H` and its values are returned.
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -752,14 +752,12 @@ Throw contexts allow matching the program context around a throw instruction up 
       \stepto & \val_{f32}~\val_{i64} & \\
       \end{array}
 
-
-
    When a throw of the form :math:`\val^m (\THROWadm~a)` occurs, we search for the maximal surrounding throw context :math:`T`,
    which means we pop any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`\val^m (\THROWadm~a)`,
    until we find an exception handler (corresponding to a try block) that :ref:`handles the exception <syntax-handler>`.
    We then append the values :math:`\val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
 
-   In other words, a thrown exception is caught when it's the continuation of a throw context in a catching try block,
+   In other words, an exception throw is caught when it is the continuation of a throw context in a catching try block,
    i.e., it is inside a catching try block, which is the innermost with respect to the throw.
 
    In this particular case, the exception is caught by the exception handler :math:`H` and its values are returned.

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -734,22 +734,22 @@ Throw contexts allow matching the program context around a throw instruction up 
 
    Assume that :math:`\expand_F(bt) = [\I32~\F32~\I64] \to [\F32~\I64]`,
    and that the tag address `a` of :math:`x` corresponds to the tag type :math:`[\F32~\I64] \to []`.
-   Let :math:`val_{i32}`, :math:`val_{f32}`, and :math:`val_{i64}` be values of type |I32|, |F32|, and |I64| respectively.
+   Let :math:`\val_{i32}`, :math:`\val_{f32}`, and :math:`\val_{i64}` be values of type |I32|, |F32|, and |I64| respectively.
 
    .. math::
       \begin{array}{ll}
-      & \hspace{-5ex} F;~val_{i32}~val_{f32}~val_{i64}~(\TRY~\X{bt}~(\THROW~x)~\CATCH~x~\END) \\
-      \stepto & F;~\LABEL_2\{\} (\CATCHadm\{a~\epsilon\}~val_{i32}~val_{f32}~val_{i64}~(\THROW~x)~\END)~\END \\
+      & \hspace{-5ex} F;~\val_{i32}~\val_{f32}~\val_{i64}~(\TRY~\X{bt}~(\THROW~x)~\CATCH~x~\END) \\
+      \stepto & F;~\LABEL_2\{\} (\CATCHadm\{a~\epsilon\}~\val_{i32}~\val_{f32}~\val_{i64}~(\THROW~x)~\END)~\END \\
       \end{array}
 
    :ref:`Handling the thrown exception <exec-throwadm>` with tag address :math:`a` in the throw context
-   :math:`T=[val_{i32}\_]`, with the exception handler :math:`H=\CATCHadm\{a~\epsilon\}` gives:
+   :math:`T=[\val_{i32}\_]`, with the exception handler :math:`H=\CATCHadm\{a~\epsilon\}` gives:
 
    .. math::
       \begin{array}{lll}
-      \stepto & F;~\LABEL_2\{\}~(\CAUGHTadm\{a~val_{f32}~val_{i64}\}~val_{f32}~val_{i64}~\END)~\END & \hspace{9ex}\ \\
-      \stepto & F;~\LABEL_2\{\}~val_{f32}~val_{i64}~\END & \hspace{9ex}\ \\
-      \stepto & val_{f32}~val_{i64} & \\
+      \stepto & F;~\LABEL_2\{\}~(\CAUGHTadm\{a~\val_{f32}~\val_{i64}\}~\val_{f32}~\val_{i64}~\END)~\END & \hspace{9ex}\ \\
+      \stepto & F;~\LABEL_2\{\}~\val_{f32}~\val_{i64}~\END & \hspace{9ex}\ \\
+      \stepto & \val_{f32}~\val_{i64} & \\
       \end{array}
 
 
@@ -759,8 +759,8 @@ Throw contexts allow matching the program context around a throw instruction up 
    until we find an exception handler (corresponding to a try block) that :ref:`handles the exception <syntax-handler>`.
    We then append the values :math:`\val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
 
-   In other words, when a throw occurs, normal execution halts and exceptional execution begins, until the throw
-   is the continuation (i.e., in the place of a :math:`\_`) of a throw context in a catching try block.
+   In other words, a thrown exception is caught when it's the continuation of a throw context in a catching try block,
+   i.e., it's inside a catching try block, which is the innermost with respect to the throw.
 
    In this particular case, the exception is caught by the exception handler :math:`H` and its values are returned.
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -732,14 +732,14 @@ Throw contexts allow matching the program context around a throw instruction up 
 .. note::
    For example, catching a simple :ref:`throw <exec-throw>` in a :ref:`try block <exec-try-catch>` would be as follows.
 
-   Assume that :math:`\expand_F(bt) = [i32 f32 i64] \to [f32 i64]`,
-   and that the tag address `a` of :math:`x` corresponds to the tag type :math:`[f32 i64] \to []`.
-   Let :math:`\val_{i32}`, :math:`\val_{f32}`, and :math:`\val_{i64}` be values of type |i32|, |f32|, and |i64| respectively.
+   Assume that :math:`\expand_F(bt) = [\I32~\F32~\I64] \to [\F32~\I64]`,
+   and that the tag address `a` of :math:`x` corresponds to the tag type :math:`[\F32~\I64] \to []`.
+   Let :math:`val_{i32}`, :math:`val_{f32}`, and :math:`val_{i64}` be values of type |I32|, |F32|, and |I64| respectively.
 
    .. math::
       \begin{array}{ll}
-      & \hspace{-5ex} F;~\val_{i32}~\val_{f32}~\val_{i64}~(\TRY~\X{bt}~(\THROW~x)~\CATCH~x~\END) \\
-      \stepto & F;~\LABEL_2\{\} (\CATCHadm\{a~\epsilon}~\val_{i32}~\val_{f32}~\val_{i64}~(\THROW~x)~\END)~\END \\
+      & \hspace{-5ex} F;~val_{i32}~val_{f32}~val_{i64}~(\TRY~\X{bt}~(\THROW~x)~\CATCH~x~\END) \\
+      \stepto & F;~\LABEL_2\{\} (\CATCHadm\{a~\epsilon\}~val_{i32}~val_{f32}~val_{i64}~(\THROW~x)~\END)~\END \\
       \end{array}
 
    :ref:`Handling the thrown exception <exec-throwadm>` with tag address :math:`a` in the throw context
@@ -747,17 +747,17 @@ Throw contexts allow matching the program context around a throw instruction up 
 
    .. math::
       \begin{array}{lll}
-      \stepto & F;~\LABEL_2\{\}~(\CAUGHTadm\{a~\val_{f32}~\val_{i64}\}~\val_{f32}~\val_{i64}~\END)~\END & \hspace{9ex}\ \\
-      \stepto & F;~\LABEL_2\{\}~\val_{f32}~\val_{i64}~\END & \hspace{9ex}\ \\
-      \stepto & \val_{f32}~\val_{i64} & \\
+      \stepto & F;~\LABEL_2\{\}~(\CAUGHTadm\{a~val_{f32}~val_{i64}\}~val_{f32}~val_{i64}~\END)~\END & \hspace{9ex}\ \\
+      \stepto & F;~\LABEL_2\{\}~val_{f32}~val_{i64}~\END & \hspace{9ex}\ \\
+      \stepto & val_{f32}~val_{i64} & \\
       \end{array}
 
 
 
-   When a throw of the form :math:`val^m (\THROWadm~a)` occurs, we search for the maximal surrounding throw context :math:`T`,
-   which means we pop any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`val^m (\THROWadm~a)`,
+   When a throw of the form :math:`\val^m (\THROWadm~a)` occurs, we search for the maximal surrounding throw context :math:`T`,
+   which means we pop any other values, labels, frames, and |CAUGHTadm| instructions surrounding the throw :math:`\val^m (\THROWadm~a)`,
    until we find an exception handler (corresponding to a try block) that :ref:`handles the exception <syntax-handler>`.
-   We then append the values :math:`val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
+   We then append the values :math:`\val^m:[t^m]` to the tag address :math:`a` into a new |CAUGHTadm| instruction which we push on the stack.
 
    In other words, when a throw occurs, normal execution halts and exceptional execution begins, until the throw
    is the continuation (i.e., in the place of a :math:`\_`) of a throw context in a catching try block.
@@ -805,7 +805,7 @@ Finally, the following definition of *evaluation context* and associated structu
    \begin{array}{llll}
    \production{(evaluation contexts)} & E &::=&
      [\_] ~|~
-     \val^\ast~E~\instr^\ast ~|~
+     val^\ast~E~\instr^\ast ~|~
      \LABEL_n\{\instr^\ast\}~E~\END \\
    \end{array}
 


### PR DESCRIPTION
Addresses @aheejin's request in a previous review comment:
https://github.com/WebAssembly/exception-handling/pull/180#discussion_r955477590

Originally I wrote this using
- `val_{i32} = (i32.const 1)`,
- `val_{f32} = (f32.const 2.0)`, and
- `val_{i64} = (i64.const 3)`,

but the example seemed then really long.
To keep the example relatively short I switched to the current version.