### PR TITLE
Add prose for reduction rule of rethrow.

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2719,30 +2719,13 @@ Control Instructions
 
 2. Let :math:`L` be the :math:`l`-th label appearing on the stack, starting from the top and counting from zero.
 
-3. Assert: due to :ref:`validation <valid-rethrow>`, :math:`L` is a catch label, i.e., a label of the form :math:`(\LCATCH~[t^\ast])`.
+3. Assert: due to :ref:`validation <valid-rethrow>`, :math:`L` is a catch label, i.e., a label of the form :math:`(\LCATCH~[t^\ast])`, which is a label followed by a caught exception in an active catch clause.
 
-4. Repeat :math:`l+1` times:
+4. Let :math:`\{a~\val^\ast\}` be the caught exception.
 
-   a. While the top of the stack is a value, a |handler|, or a |CAUGHTadm| instruction, do:
+5. Push the values :math:`\val^\ast` onto the stack.
 
-      i. Pop the instruction from the stack.
-
-   b. Assert: due to :ref:`validation <valid-rethrow>`, the top of the stack now is a label.
-
-   c. Pop the label from the stack.
-
-5. Assert: due to **TODO**, the last two instructions popped are a |CAUGHTadm| instruction and the :math:`l+1`-th label, in that order.
-
-.. todo::
-   Justify the existence of a |CAUGHTadm| here. Perhaps extend some typing rule?
-
-6. Let :math:`\CAUGHTadm\{a~\val^\ast\}` be the instruction after the label :math:`L`.
-
-7. Put all the popped values back on the stack, except the last instruction, the |RETHROW|.
-
-8. Push the values :math:`\val^\ast` onto the stack.
-
-8. :ref:`Throw <exec-throwadm>` an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`.
+6. :ref:`Throw <exec-throwadm>` an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`.
 
 .. math::
    ~\\[-1ex]

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2715,7 +2715,7 @@ Control Instructions
 :math:`\RETHROW~l`
 ..................
 
-1. Assert: due to :ref:`validation <valid-rethrow>`, the stack contans at least :math:`l+1` labels.
+1. Assert: due to :ref:`validation <valid-rethrow>`, the stack contains at least :math:`l+1` labels.
 
 2. Let :math:`L` be the :math:`l`-th label appearing on the stack, starting from the top and counting from zero.
 
@@ -2723,7 +2723,7 @@ Control Instructions
 
 4. Repeat :math:`l+1` times:
 
-   a. While the instruction at the top of the stack is a value, a |handler|, or a |CAUGHTadm| instruction, do:
+   a. While the top of the stack is a value, a |handler|, or a |CAUGHTadm| instruction, do:
 
       i. Pop the instruction from the stack.
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2715,14 +2715,40 @@ Control Instructions
 :math:`\RETHROW~l`
 ..................
 
+1. Assert: due to :ref:`validation <valid-rethrow>`, the stack contans at least :math:`l+1` labels.
+
+2. Let :math:`L` be the :math:`l`-th label appearing on the stack, starting from the top and counting from zero.
+
+3. Assert: due to :ref:`validation <valid-rethrow>`, :math:`L` is a catch label, i.e., a label of the form :math:`(\LCATCH~[t^\ast])`.
+
+4. Repeat :math:`l+1` times:
+
+   a. While the instruction at the top of the stack is a value, a |handler|, or a |CAUGHTadm| instruction, do:
+
+      i. Pop the instruction from the stack.
+
+   b. Assert: due to :ref:`validation <valid-br>`, the top of the stack now is a label.
+
+   c. Pop the label from the stack.
+
+5. Assert: due to **TODO**, the last two instructions popped are a |CAUGHTadm| instruction and the :math:`l+1`-th label, in that order.
+
 .. todo::
-   Add prose for the |RETHROW| execution step.
+   Justify the existence of a |CAUGHTadm| here. Perhaps extend some typing rule?
+
+6. Let :math:`\CAUGHTadm\{a~\val^\ast\}` be the instruction after the label :math:`L`.
+
+7. Put all the popped values back on the stack, except the last instruction, the |RETHROW|.
+
+8. Push the values :math:`\val^\ast` onto the stack.
+
+8. :ref:`Throw <exec-throwadm>` an exception with :ref:`tag address <syntax-tagaddr>` :math:`a`.
 
 .. math::
    ~\\[-1ex]
    \begin{array}{lclr@{\qquad}}
-   \CAUGHTadm\{a~\val^n\}~\XB^l[\RETHROW~l]~\END &\stepto&
-   \CAUGHTadm\{a~\val^n\}~\XB^l[\val^n~(\THROWadm~a)]~\END \\
+   \CAUGHTadm\{a~\val^\ast\}~\XB^l[\RETHROW~l]~\END &\stepto&
+   \CAUGHTadm\{a~\val^\ast\}~\XB^l[\val^\ast~(\THROWadm~a)]~\END \\
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2727,7 +2727,7 @@ Control Instructions
 
       i. Pop the instruction from the stack.
 
-   b. Assert: due to :ref:`validation <valid-br>`, the top of the stack now is a label.
+   b. Assert: due to :ref:`validation <valid-rethrow>`, the top of the stack now is a label.
 
    c. Pop the label from the stack.
 


### PR DESCRIPTION
<del>Why WIP:</del>
--------
<del>I'm not sure how to justify step 5 of the prose, that is how to assert that the lth label surrounding a rethrow instruction has a CAUGHTadm{a val*} next to it.</del>

- Also slightly changed notation to match the [formal overview document](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions-formal-overview.md).