### PR TITLE
Add prose for typing rule of try-delegate.

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1415,8 +1415,14 @@ Control Instructions
 :math:`\TRY~\blocktype~\instr^\ast~\DELEGATE~l`
 ...............................................
 
-.. todo::
-   Add prose.
+* The label :math:`C.\CLABELS[l]` must be defined in the context.
+
+* The :ref:`block type <syntax-blocktype>` must be :ref:`valid <valid-blocktype>` as some :ref:`function type <syntax-functype>` :math:`[t_1^\ast] \to [t_2^\ast]`.
+
+* Let :math:`C'` be the same :ref:`context <context>` as :math:`C`, but with the :ref:`result type <syntax-resulttype>` :math:`[t_2^\ast]` prepended to the |CLABELS| vector.
+
+* Under context :math:`C'`,
+  the instruction sequence :math:`\instr^\ast` must be :ref:`valid <valid-instr-seq>` with type :math:`[t_1^\ast] \to [t_2^\ast]`.
 
 .. math::
    \frac{
@@ -1424,11 +1430,18 @@ Control Instructions
      \qquad
      C,\CLABELS\,[t_2^\ast] \vdashinstrseq \instr^\ast : [t_1^\ast]\to[t_2^\ast]
      \qquad
-     C.\CLABELS[l] = [t^\ast]
+     C.\CLABELS[l] = [t_0^\ast]
    }{
    C \vdashinstrseq \TRY~\blocktype~\instr^\ast~\DELEGATE~l : [t_1^\ast]\to[t_2^\ast]
    }
 
+.. note::
+   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\, [t^\ast]` inserts the new label type at index :math:`0`, shifting all others.
+
+   The :ref:`label index <syntax-labelidx>` after |DELEGATE| refers to a label surrounding the :ref:`try-delegate <syntax-try-delegate>` instruction. The furthest label it can refer to is the label inserted by the frame. For example, :math:`\TRY~\dots~\DELEGATE~0` may appear without any explicitly surrounding block, in which case the label 0 refers to the label of the frame.
+
+.. todo::
+   Add references/links to "the label of the frame": Where is this label introduced?
 
 .. _valid-throw:
 

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1436,12 +1436,8 @@ Control Instructions
    }
 
 .. note::
-   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\, [t^\ast]` inserts the new label type at index :math:`0`, shifting all others.
+   The :ref:`label index <syntax-labelidx>` space in the :ref:`context <context>` :math:`C` contains the most recent label first, so that :math:`C.\CLABELS[l]` performs a relative lookup as expected.
 
-   The :ref:`label index <syntax-labelidx>` after |DELEGATE| refers to a label surrounding the :ref:`try-delegate <syntax-try-delegate>` instruction. The furthest label it can refer to is the label inserted by the frame. For example, :math:`\TRY~\dots~\DELEGATE~0` may appear without any explicitly surrounding block, in which case the label 0 refers to the label of the frame.
-
-.. todo::
-   Add references/links to "the label of the frame": Where is this label introduced?
 
 .. _valid-throw:
 


### PR DESCRIPTION
Also slightly adjusted notation to match the formal overview.

<del>Why WIP:

<del>The prose is finished, but while trying to add explanatory notes, I couldn't find a reference in the spec to the validation label that the frame pushes to the context.

EDIT:
WIP is no longer necessary after addressing review comments. 
