### PR TITLE
Misc. fixes in formal spec

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -2649,7 +2649,7 @@ Control Instructions
 
 3. Let :math:`L` be the label whose arity is :math:`n` and whose continuation is the end of the |TRY| instruction.
 
-4. Let :math:`H` be the :ref:`delegating exception handler <syntax-handler>` :math:`\DELEGATEadm\{l\}`, targeting the :math:`l` surrounding block.
+4. Let :math:`H` be the :ref:`delegating exception handler <syntax-handler>` :math:`\DELEGATEadm\{l\}`, targeting the :math:`l`-th surrounding block.
 
 5. Assert: due to :ref:`validation <valid-try-delegate>`, there are at least :math:`m` values on the top of the stack.
 
@@ -2663,7 +2663,7 @@ Control Instructions
    ~\\[-1ex]
    \begin{array}{lcl}
    F; \val^m~(\TRY~\X{bt}~\instr^\ast~\DELEGATE~l) &\stepto&
-   F; \LABEL_n\{\}~(\DELEGATEadm\{l\}~\val^m~\instr^\ast~\END)~\END \\
+   F; \LABEL_n\{\epsilon\}~(\DELEGATEadm\{l\}~\val^m~\instr^\ast~\END)~\END \\
    && (\iff \expand_F(\X{bt}) = [t_1^m] \to [t_2^n])
    \end{array}
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -74,7 +74,7 @@ Results
 ~~~~~~~
 
 A *result* is the outcome of a computation.
-It is either a sequence of :ref:`values <syntax-val>`, a :ref:`trap <syntax-trap>`, or an uncaught exception wrapped in its throw context.
+It is either a sequence of :ref:`values <syntax-val>`, a :ref:`trap <syntax-trap>`, or an uncaught exception wrapped in its :ref:`throw context <syntax-ctxt-throw>`.
 
 .. math::
    \begin{array}{llcl}
@@ -712,7 +712,8 @@ the following syntax of *throw contexts* is defined, as well as associated struc
 .. math::
    \begin{array}{llll}
    \production{(throw contexts)} & \XT &::=&
-     [\_] | \val^\ast~\XT~\instr^\ast \\ &&|&
+     [\_] \\ &&|&
+     \val^\ast~\XT~\instr^\ast \\ &&|&
      \LABEL_n\{\instr^\ast\}~\XT~\END \\ &&|&
      \CAUGHTadm\{\tagaddr~\val^\ast\}~\XT~\END \\ &&|&
      \FRAME_n\{F\}~\XT~\END \\

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1424,6 +1424,8 @@ Control Instructions
 * Under context :math:`C'`,
   the instruction sequence :math:`\instr^\ast` must be :ref:`valid <valid-instr-seq>` with type :math:`[t_1^\ast] \to [t_2^\ast]`.
 
+* Then the compound instruction is valid with type :math:`[t_1^\ast] \to [t_2^\ast]`.
+
 .. math::
    \frac{
      C \vdashblocktype \blocktype : [t_1^\ast] \to [t_2^\ast]


### PR DESCRIPTION
- Add missing `th`
- Add missing `Then the compound instruction is valid with type [t1*]->[t2*].`
- Add a link to "Throw Contexts"
- Tidy up the equation for throw contexts
- Add missing `epsilon`