### PR TITLE
[js-api] Mention opaque data requirement

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1045,6 +1045,7 @@ This slot holds a [=function address=] relative to the [=surrounding agent=]'s [
         1. Set |i| to |i| + 1.
     1. Let (|store|, |ret|) be the result of [=func_invoke=](|store|, |funcaddr|, |args|).
     1. Note: The expectation is that [=func_invoke=] will be updated to return (|store|, <var ignore>val</var>* | [=error=] | (exception |exntag| |payload| |opaqueData|)).
+    1. Note: The core spec does not have a notion of |opaqueData| in itself, but a backing store that serves as |opaqueData| is necessary to complete this step.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
     1. If |ret| is [=error=], throw an exception. This exception should be a WebAssembly {{RuntimeError}} exception, unless otherwise indicated by <a href="#errors">the WebAssembly error mapping</a>.
     1. If |ret| is exception |exntag| |payload| |opaqueData|, then


### PR DESCRIPTION
This basically does the "handwaving" we discussed in https://github.com/WebAssembly/exception-handling/pull/218#issuecomment-1308503237. I think adding a concept of a backing store through backdoors in the core spec is not very feasible, so this is what we can do practically at this point.

Hopefully resolves #242.