### PR TITLE
[js-api] Rename variables to be consistent (NFC)

### DIFF
--- a/test/js-api/exception/constructor.tentative.any.js
+++ b/test/js-api/exception/constructor.tentative.any.js
@@ -18,8 +18,8 @@ test(() => {
 }, "No arguments");
 
 test(() => {
-  const argument = new WebAssembly.Tag({ parameters: [] });
-  assert_throws_js(TypeError, () => WebAssembly.Exception(argument));
+  const tag = new WebAssembly.Tag({ parameters: [] });
+  assert_throws_js(TypeError, () => WebAssembly.Exception(tag));
 }, "Calling");
 
 test(() => {
@@ -53,10 +53,10 @@ test(() => {
     ["i64", undefined],
   ];
   for (const typeAndArg of typesAndArgs) {
-    const exn = new WebAssembly.Tag({ parameters: [typeAndArg[0]] });
+    const tag = new WebAssembly.Tag({ parameters: [typeAndArg[0]] });
     assert_throws_js(
       TypeError,
-      () => new WebAssembly.Exception(exn, typeAndArg[1])
+      () => new WebAssembly.Exception(tag, typeAndArg[1])
     );
   }
 }, "Invalid exception argument");

--- a/test/js-api/exception/toString.tentative.any.js
+++ b/test/js-api/exception/toString.tentative.any.js
@@ -3,8 +3,8 @@
 test(() => {
   const argument = { parameters: [] };
   const tag = new WebAssembly.Tag(argument);
-  const exception = new WebAssembly.Exception(tag, []);
-  assert_class_string(exception, "WebAssembly.Exception");
+  const exn = new WebAssembly.Exception(tag, []);
+  assert_class_string(exn, "WebAssembly.Exception");
 }, "Object.prototype.toString on an Exception");
 
 test(() => {


### PR DESCRIPTION
This renames variables to be consistent among exception JS API tests. Now `WebAssembly.Tag`s are named `tag` or prefixed with it and `WebAssembly.Exception`s are named `exn` or prefixed with it.

Currently some `WebAssembly.Tag`s are named `exn` because `Tag` was used to call `Exception` in the earlier version of the JS API, which this PR fixes.