### PR TITLE
[js-api] Add missing EnforceRange to getArg argument.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1270,7 +1270,7 @@ dictionary ExceptionOptions {
 [LegacyNamespace=WebAssembly, Exposed=(Window,Worker,Worklet)]
 interface Exception {
   constructor(Tag exceptionTag, sequence&lt;any> payload, optional ExceptionOptions options = {});
-  any getArg(Tag exceptionTag, unsigned long index);
+  any getArg(Tag exceptionTag, [EnforceRange] unsigned long index);
   boolean is(Tag exceptionTag);
   readonly attribute (DOMString or undefined) stack;
 };

--- a/test/js-api/exception/getArg.tentative.any.js
+++ b/test/js-api/exception/getArg.tentative.any.js
@@ -43,7 +43,7 @@ test(() => {
   const tag = new WebAssembly.Tag({ parameters: [] });
   const exn = new WebAssembly.Exception(tag, []);
   for (const value of outOfRangeValues) {
-    assert_throws_js(RangeError, () => exn.getArg(tag, value));
+    assert_throws_js(TypeError, () => exn.getArg(tag, value));
   }
 }, "Getting out-of-range argument");
 


### PR DESCRIPTION
All other 'unsigned long' arguments in the JS API have EnforceRange extended attributes. I assume this one was missed accidentally.