### PR TITLE
[js-api] Test Wasm-defined tag in rethrow identity test

### DIFF
--- a/test/js-api/exception/identity.tentative.any.js
+++ b/test/js-api/exception/identity.tentative.any.js
@@ -17,7 +17,7 @@ test(() => {
   const wasmTagIndex = builder.addTag(kSig_v_i);
   builder.addExportOfKind("wasmTag", kExternalTag, wasmTagIndex);
   const throwWasmTagExnIndex = builder.addImport("module", "throwWasmTagExn", kSig_v_v);
-  // Will be assigned later
+  // Will be assigned after an instance is created
   let wasmTagExn = null;
   let wasmTagExnSamePayload = null;
   let wasmTagExnDiffPayload = null;

--- a/test/js-api/exception/identity.tentative.any.js
+++ b/test/js-api/exception/identity.tentative.any.js
@@ -86,9 +86,9 @@ test(() => {
 
   const buffer = builder.toBuffer();
 
-  // The exception object's identity should be preserved across 'rethrow's in
-  // Wasm code. Do tests with a tag defined in JS.
   WebAssembly.instantiate(buffer, imports).then(result => {
+    // The exception object's identity should be preserved across 'rethrow's in
+    // Wasm code. Do tests with a tag defined in JS.
     try {
       result.instance.exports.catch_js_tag_rethrow();
     } catch (e) {
@@ -105,10 +105,8 @@ test(() => {
       assert_not_equals(e, jsTagExnSamePayload);
       assert_not_equals(e, jsTagExnDiffPayload);
     }
-  });
 
-  // Do the same tests with a tag defined in Wasm.
-  WebAssembly.instantiate(buffer, imports).then(result => {
+    // Do the same tests with a tag defined in Wasm.
     const wasmTag = result.instance.exports.wasmTag;
     wasmTagExn = new WebAssembly.Exception(wasmTag, [42]);
     wasmTagExnSamePayload = new WebAssembly.Exception(wasmTag, [42]);

--- a/test/js-api/exception/identity.tentative.any.js
+++ b/test/js-api/exception/identity.tentative.any.js
@@ -13,9 +13,19 @@ test(() => {
   const jsTagExnDiffPayload = new WebAssembly.Exception(jsTag, [53]);
   const throwJSTagExnIndex = builder.addImport("module", "throwJSTagExn", kSig_v_v);
 
+  // Tag defined in Wasm and exported to JS
+  const wasmTagIndex = builder.addTag(kSig_v_i);
+  builder.addExportOfKind("wasmTag", kExternalTag, wasmTagIndex);
+  const throwWasmTagExnIndex = builder.addImport("module", "throwWasmTagExn", kSig_v_v);
+  // Will be assigned later
+  let wasmTagExn = null;
+  let wasmTagExnSamePayload = null;
+  let wasmTagExnDiffPayload = null;
+
   const imports = {
     module: {
       throwJSTagExn: function() { throw jsTagExn; },
+      throwWasmTagExn: function() { throw wasmTagExn; },
       jsTag: jsTag
     }
   };
@@ -34,6 +44,20 @@ test(() => {
     ])
     .exportFunc();
 
+  // Call a JS function that throws an exception using a Wasm-defined tag,
+  // catches it with a 'catch' instruction, and rethrows it.
+  builder
+    .addFunction("catch_wasm_tag_rethrow", kSig_v_v)
+    .addBody([
+      kExprTry, kWasmStmt,
+        kExprCallFunction, throwWasmTagExnIndex,
+      kExprCatch, wasmTagIndex,
+        kExprDrop,
+        kExprRethrow, 0x00,
+      kExprEnd
+    ])
+    .exportFunc();
+
   // Call a JS function that throws an exception using a JS-defined tag, catches
   // it with a 'catch_all' instruction, and rethrows it.
   builder
@@ -41,6 +65,19 @@ test(() => {
     .addBody([
       kExprTry, kWasmStmt,
         kExprCallFunction, throwJSTagExnIndex,
+      kExprCatchAll,
+        kExprRethrow, 0x00,
+      kExprEnd
+    ])
+    .exportFunc();
+
+  // Call a JS function that throws an exception using a Wasm-defined tag,
+  // catches it with a 'catch_all' instruction, and rethrows it.
+  builder
+    .addFunction("catch_all_wasm_tag_rethrow", kSig_v_v)
+    .addBody([
+      kExprTry, kWasmStmt,
+        kExprCallFunction, throwWasmTagExnIndex,
       kExprCatchAll,
         kExprRethrow, 0x00,
       kExprEnd
@@ -67,6 +104,28 @@ test(() => {
       assert_equals(e, jsTagExn);
       assert_not_equals(e, jsTagExnSamePayload);
       assert_not_equals(e, jsTagExnDiffPayload);
+    }
+  });
+
+  // Do the same tests with a tag defined in Wasm.
+  WebAssembly.instantiate(buffer, imports).then(result => {
+    const wasmTag = result.instance.exports.wasmTag;
+    wasmTagExn = new WebAssembly.Exception(wasmTag, [42]);
+    wasmTagExnSamePayload = new WebAssembly.Exception(wasmTag, [42]);
+    wasmTagExnDiffPayload = new WebAssembly.Exception(wasmTag, [53]);
+    try {
+      result.instance.exports.catch_wasm_tag_rethrow();
+    } catch (e) {
+      assert_equals(e, wasmTagExn);
+      assert_not_equals(e, wasmTagExnSamePayload);
+      assert_not_equals(e, wasmTagExnDiffPayload);
+    }
+    try {
+      result.instance.exports.catch_all_wasm_tag_rethrow();
+    } catch (e) {
+      assert_equals(e, wasmTagExn);
+      assert_not_equals(e, wasmTagExnSamePayload);
+      assert_not_equals(e, wasmTagExnDiffPayload);
     }
   });
 }, "Identity check");


### PR DESCRIPTION
This addresses
https://github.com/WebAssembly/exception-handling/pull/253#issuecomment-1433703216 by adding a set of tests that use a Wasm-defined and exported tag.