### PR TITLE
[js-api] Add more tests reusing payload

### DIFF
--- a/test/js-api/exception/identity.tentative.any.js
+++ b/test/js-api/exception/identity.tentative.any.js
@@ -47,11 +47,38 @@ test(() => {
     ])
     .exportFunc();
 
+  // Call a JS function that throws an exception, catches it with a 'catch'
+  // instruction, and returns its i32 payload.
+  builder
+    .addFunction("catch_js_tag_return_payload", kSig_i_v)
+    .addBody([
+      kExprTry, kWasmI32,
+        kExprCallFunction, throwJSTagExnIndex,
+        kExprI32Const, 0x00,
+      kExprCatch, jsTagIndex,
+        kExprReturn,
+      kExprEnd,
+    ])
+    .exportFunc();
+
+  // Call a JS function that throws an exception, catches it with a 'catch'
+  // instruction, and throws a new exception using that payload.
+  builder
+    .addFunction("catch_js_tag_throw_payload", kSig_v_v)
+    .addBody([
+      kExprTry, kWasmStmt,
+        kExprCallFunction, throwJSTagExnIndex,
+      kExprCatch, jsTagIndex,
+        kExprThrow, jsTagIndex,
+      kExprEnd,
+    ])
+    .exportFunc();
+
   const buffer = builder.toBuffer();
 
-  // The exception object's identity should be preserved across 'rethrow's in
-  // Wasm code. Do tests with a tag defined in JS.
   WebAssembly.instantiate(buffer, imports).then(result => {
+    // The exception object's identity should be preserved across 'rethrow's in
+    // Wasm code. Do tests with a tag defined in JS.
     try {
       result.instance.exports.catch_js_tag_rethrow();
     } catch (e) {
@@ -67,6 +94,20 @@ test(() => {
       assert_equals(e, jsTagExn);
       assert_not_equals(e, jsTagExnSamePayload);
       assert_not_equals(e, jsTagExnDiffPayload);
+    }
+
+    // This function catches the exception and returns its i32 payload, which
+    // should match the original payload.
+    assert_equals(result.instance.exports.catch_js_tag_return_payload(), 42);
+
+    // This function catches the exception and throws a new exception using the
+    // its payload. Even if the payload is reused, the exception objects should
+    // not compare equal.
+    try {
+      result.instance.exports.catch_js_tag_throw_payload();
+    } catch (e) {
+      assert_equals(e.getArg(jsTag, 0), 42);
+      assert_not_equals(e, jsTagExn);
     }
   });
 }, "Identity check");

--- a/test/js-api/exception/identity.tentative.any.js
+++ b/test/js-api/exception/identity.tentative.any.js
@@ -94,7 +94,7 @@ test(() => {
         kExprI32Const, 0x00,
       kExprCatch, jsTagIndex,
         kExprReturn,
-      kExprEnd,
+      kExprEnd
     ])
     .exportFunc();
 
@@ -107,7 +107,9 @@ test(() => {
         kExprCallFunction, throwJSTagExnIndex,
       kExprCatch, jsTagIndex,
         kExprThrow, jsTagIndex,
-      kExprEnd,
+      kExprEnd
+    ])
+    .exportFunc();
 
   const buffer = builder.toBuffer();
 


### PR DESCRIPTION
As suggested in
https://github.com/WebAssembly/exception-handling/pull/256#discussion_r1109501365, this adds two more tests:
- JS throws an exception, Wasm catches it and returns the payload.
- JS throws an exception, Wasm catches it and throws a new exception using that payload.