### PR TITLE
Added Exception Handling entry to `document/core/appendix/changes.rst`

### DIFF
--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -143,17 +143,15 @@ Added vector type and instructions that manipulate multiple numeric values in pa
 Exception Handling
 ..................
 
-Added tag definitions, imports, and exports, and instructions to throw and catch exceptions [#proposal-eh]_
+Added tag definitions, imports, and exports, and instructions to throw and catch exceptions [#proposal-exceptions]_
 
-* New :ref:`tag type <syntax-tagtype>`: :math:`[t^\ast]\to[]`-
-
-* New :ref:`tag section <binary-tagsec>` in binary format.
+* Modules may :ref:`define <syntax-tagtype>`, :ref:`import <syntax-import>`, and :ref:`export <syntax-export>` tags.
 
 * New exception throwing :ref:`control instructions <syntax-instr-control>`: :math:`\THROW` and :math:`\RETHROW`.
 
 * New handler :ref:`control instructions <syntax-instr-control>`: :math:`(\TRY~\X{bt}~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?\END)` and :math:`(\TRY~\X{bt}~\instr^\ast~\DELEGATE~l)`.
 
-* New uncaught exception :ref:`result <syntax-result>`.
+* New :ref:`tag section <binary-tagsec>` in binary format.
 
 
 .. [#proposal-signext]

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -151,7 +151,7 @@ Added tag type, instructions that throw exceptions of a tag type, and instructio
 
 * New exception throwing :ref:`control instructions <syntax-instr-control>`: :math:`\THROW` and :math:`\RETHROW`.
 
-* New handler :ref:`control instructions <syntax-instr-control>`: :math:`\TRY~\bt~\instr^\ast~(\CATCH~\tagidx~\instr^\ast)^\ast~(\CATCHALL~\instr^\ast)^?\END`, :math:`\TRY~\bt~\instr^\ast~\DELEGATE~\labelidx`.
+* New handler :ref:`control instructions <syntax-instr-control>`: :math:`\TRY~\X{bt}~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?\END`, :math:`\TRY~\X{bt}~\instr^\ast~\DELEGATE~l`.
 
 * New uncaught exception :ref:`result <syntax-result>`.
 

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -138,6 +138,24 @@ Added vector type and instructions that manipulate multiple numeric values in pa
 * New injection/projection :ref:`vector instructions <syntax-instr-vec>`: :math:`\K{i}\!N\!\K{x}\!M\!\K{.splat}`, :math:`\K{f}\!N\!\K{x}\!M\!\K{.splat}`, :math:`\K{i}\!N\!\K{x}\!M\!\K{.bitmask}`
 
 
+.. index:: instructions, exception, tag type, tag, handler
+
+Exception Handling
+..................
+
+Added tag type, instructions that throw exceptions of a tag type, and instructions that handle exceptions. [#proposal-eh]_
+
+* New :ref:`tag type <syntax-tagtype>`: :math:`[t^\ast]\to[]`-
+
+* New :ref:`tag section <binary-tagsec>` in binary format.
+
+* New exception throwing :ref:`control instructions <syntax-instr-control>`: :math:`\THROW` and :math:`\RETHROW`.
+
+* New handler :ref:`control instructions <syntax-instr-control>`: :math:`\TRY~\bt~\instr^\ast~(\CATCH~\tagidx~\instr^\ast)^\ast~(\CATCHALL~\instr^\ast)^?\END`, :math:`\TRY~\bt~\instr^\ast~\DELEGATE~\labelidx`.
+
+* New uncaught exception :ref:`result <syntax-result>`.
+
+
 .. [#proposal-signext]
    https://github.com/WebAssembly/spec/tree/main/proposals/sign-extension-ops/
 
@@ -155,3 +173,6 @@ Added vector type and instructions that manipulate multiple numeric values in pa
 
 .. [#proposal-vectype]
    https://github.com/WebAssembly/spec/tree/main/proposals/simd/
+
+.. [#proposal-eh]
+   https://github.com/WebAssembly/spec/tree/main/proposals/exception-handling/

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -143,7 +143,7 @@ Added vector type and instructions that manipulate multiple numeric values in pa
 Exception Handling
 ..................
 
-Added tag type, instructions that throw exceptions of a tag type, and instructions that handle exceptions. [#proposal-eh]_
+Added tag definitions, imports, and exports, and instructions to throw and catch exceptions [#proposal-eh]_
 
 * New :ref:`tag type <syntax-tagtype>`: :math:`[t^\ast]\to[]`-
 
@@ -151,7 +151,7 @@ Added tag type, instructions that throw exceptions of a tag type, and instructio
 
 * New exception throwing :ref:`control instructions <syntax-instr-control>`: :math:`\THROW` and :math:`\RETHROW`.
 
-* New handler :ref:`control instructions <syntax-instr-control>`: :math:`\TRY~\X{bt}~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?\END`, :math:`\TRY~\X{bt}~\instr^\ast~\DELEGATE~l`.
+* New handler :ref:`control instructions <syntax-instr-control>`: :math:`(\TRY~\X{bt}~\instr_1^\ast~(\CATCH~x~\instr_2^\ast)^\ast~(\CATCHALL~\instr_3^\ast)^?\END)` and :math:`(\TRY~\X{bt}~\instr^\ast~\DELEGATE~l)`.
 
 * New uncaught exception :ref:`result <syntax-result>`.
 
@@ -174,5 +174,5 @@ Added tag type, instructions that throw exceptions of a tag type, and instructio
 .. [#proposal-vectype]
    https://github.com/WebAssembly/spec/tree/main/proposals/simd/
 
-.. [#proposal-eh]
+.. [#proposal-exceptions]
    https://github.com/WebAssembly/spec/tree/main/proposals/exception-handling/


### PR DESCRIPTION
Please note:

Apart from try-catch and try-delegate, all other instructions in `changes.rst` are given without the immediates or any arguments that follow them. Since try-catch and try-delegate are the only new structured block instructions I guessed it is ok to include the full form of these new instructions here.