### PR TITLE
Test breaking out of a try

### DIFF
--- a/test/legacy/exceptions/try_catch.wast
+++ b/test/legacy/exceptions/try_catch.wast
@@ -167,6 +167,14 @@
       (catch $e0)
     )
   )
+
+  (func (export "break-try-catch")
+    (try (do (br 0)) (catch $e0))
+  )
+
+  (func (export "break-try-catch_all")
+    (try (do (br 0)) (catch_all))
+  )
 )
 
 (assert_return (invoke "empty-catch"))
@@ -210,6 +218,9 @@
 
 (assert_exception (invoke "return-call-in-try-catch"))
 (assert_exception (invoke "return-call-indirect-in-try-catch"))
+
+(assert_return (invoke "break-try-catch"))
+(assert_return (invoke "break-try-catch_all"))
 
 (module
   (func $imported-throw (import "test" "throw"))

--- a/test/legacy/exceptions/try_delegate.wast
+++ b/test/legacy/exceptions/try_delegate.wast
@@ -145,6 +145,46 @@
       (catch $e0)
     )
   )
+
+  (func (export "break-try-delegate")
+    (try (do (br 0)) (delegate 0))
+  )
+
+  (func (export "break-and-call-throw") (result i32)
+    (try $outer (result i32)
+      (do
+        (try (result i32)
+          (do
+            (block $a
+              (try (do (br $a)) (delegate $outer))
+            )
+            (call $throw-void)
+            (i32.const 0)
+          )
+          (catch $e0 (i32.const 1))
+        )
+      )
+      (catch $e0 (i32.const 2))
+    )
+  )
+
+  (func (export "break-and-throw") (result i32)
+    (try $outer (result i32)
+      (do
+        (try (result i32)
+          (do
+            (block $a
+              (try (do (br $a)) (delegate $outer))
+            )
+            (throw $e0)
+            (i32.const 0)
+          )
+          (catch $e0 (i32.const 1))
+        )
+      )
+      (catch $e0 (i32.const 2))
+    )
+  )
 )
 
 (assert_return (invoke "delegate-no-throw") (i32.const 1))
@@ -172,6 +212,11 @@
 
 (assert_exception (invoke "return-call-in-try-delegate"))
 (assert_exception (invoke "return-call-indirect-in-try-delegate"))
+
+(assert_return (invoke "break-try-delegate"))
+
+(assert_return (invoke "break-and-call-throw") (i32.const 1))
+(assert_return (invoke "break-and-throw") (i32.const 1))
 
 (assert_malformed
   (module quote "(module (func (delegate 0)))")


### PR DESCRIPTION
Tests that breaking out of a try resets the exception handler correctly.

See WebAssembly/wabt#2203