### PR TITLE
[docs] Fix typo

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -3168,7 +3168,7 @@ on the top of the stack.
 
        iii. Else if :math:`a_1^? = a`, then:
 
-            * :ref:`Enter <exec-caughtadm-enter>` the block :math:`\val^n~\instr^\ast` with caught exception :math:`a~\val^n`.
+            * :ref:`Enter <exec-caughtadm-enter>` the block :math:`\instr^\ast` with caught exception :math:`a~\val^n`.
 
        iv. Else, pop the first handler from :math:`H`.
 


### PR DESCRIPTION
If I understand correctly, enter the block with caught exception { $val^n$ } may push the value on stack so we don't have to enter the block $val^n$ $instr^*$.