### PR TITLE
Fix links to legacy spec documents

### DIFF
--- a/document/index.html
+++ b/document/index.html
@@ -69,8 +69,17 @@ To support the <em>embedding</em> of WebAssembly into different environments, it
   <ul>
     <li><p><b>Legacy Exception Handling</b>: defines additional instructions for exception handling that may still be available in some engines and tools, specifically web browsers.</p>
       <ul>
-        <li><a href="legacy/exceptions/">Browser version</a></li>
-        <li><a href="legacy/exceptions/_download/WebAssembly-Legacy-Exceptions.pdf">PDF version</a></li>
+        <li><p><b>Core specification</b></p>
+          <ul>
+            <li><a href="legacy/exceptions/core/">Browser version</a></li>
+            <li><a href="legacy/exceptions/core/_download/WebAssembly-Legacy-Exceptions.pdf">PDF version</a></li>
+          </ul>
+        </li>
+        <li><p><b>JavaScirpt Embedding</b></p>
+          <ul>
+            <li><a href="legacy/exceptions/js-api/">W3C version</a></li>
+          </ul>
+        </li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
#303 broke the core spec links. This fixes it by adding `core/` to the directory links and also adds the JS API spec link to the web page.