### PR TITLE
[js-api] Sync with WPT tests

### DIFF
--- a/test/js-api/exception/constructor.tentative.any.js
+++ b/test/js-api/exception/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 test(() => {

--- a/test/js-api/exception/getArg.tentative.any.js
+++ b/test/js-api/exception/getArg.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/test/js-api/exception/is.tentative.any.js
+++ b/test/js-api/exception/is.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/test/js-api/exception/toString.tentative.any.js
+++ b/test/js-api/exception/toString.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { parameters: [] };

--- a/test/js-api/instanceTestFactory.js
+++ b/test/js-api/instanceTestFactory.js
@@ -237,7 +237,7 @@ const instanceTestFactory = [
 
       builder.addGlobal(kWasmI32, true)
         .exportAs("")
-        .init = 7;
+        .init = wasmI32Const(7);
 
       const buffer = builder.toBuffer();
 
@@ -273,10 +273,10 @@ const instanceTestFactory = [
 
       builder.addGlobal(kWasmI32, true)
         .exportAs("global")
-        .init = 7;
+        .init = wasmI32Const(7);
       builder.addGlobal(kWasmF64, true)
         .exportAs("global2")
-        .init = 1.2;
+        .init = wasmF64Const(1.2);
 
       builder.addMemory(4, 8, true);
 

--- a/test/js-api/module/exports.any.js
+++ b/test/js-api/module/exports.any.js
@@ -109,10 +109,10 @@ test(() => {
 
   builder.addGlobal(kWasmI32, true)
     .exportAs("global")
-    .init = 7;
+    .init = wasmI32Const(7);
   builder.addGlobal(kWasmF64, true)
     .exportAs("global2")
-    .init = 1.2;
+    .init = wasmF64Const(1.2);
 
   builder.addMemory(0, 256, true);
 
@@ -167,7 +167,7 @@ test(() => {
 
   builder.addGlobal(kWasmI32, true)
     .exportAs("")
-    .init = 7;
+    .init = wasmI32Const(7);
 
   const buffer = builder.toBuffer()
   const module = new WebAssembly.Module(buffer);

--- a/test/js-api/tag/constructor.tentative.any.js
+++ b/test/js-api/tag/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 test(() => {

--- a/test/js-api/tag/toString.tentative.any.js
+++ b/test/js-api/tag/toString.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { parameters: [] };

--- a/test/js-api/tag/type.tentative.any.js
+++ b/test/js-api/tag/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -581,6 +581,16 @@ class Binary {
     }
   }
 
+  emit_type(type) {
+    if ((typeof type) == 'number') {
+      this.emit_u8(type >= 0 ? type : type & kLeb128Mask);
+    } else {
+      this.emit_u8(type.opcode);
+      if ('depth' in type) this.emit_u8(type.depth);
+      this.emit_heap_type(type.heap_type);
+    }
+  }
+
   emit_header() {
     this.emit_bytes([
       kWasmH0, kWasmH1, kWasmH2, kWasmH3, kWasmV0, kWasmV1, kWasmV2, kWasmV3
@@ -925,11 +935,11 @@ class WasmModuleBuilder {
           section.emit_u8(kWasmFunctionTypeForm);
           section.emit_u32v(type.params.length);
           for (let param of type.params) {
-            section.emit_u8(param);
+            section.emit_type(param);
           }
           section.emit_u32v(type.results.length);
           for (let result of type.results) {
-            section.emit_u8(result);
+            section.emit_type(result);
           }
         }
       });

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -97,8 +97,35 @@ let kWasmI64 = 0x7e;
 let kWasmF32 = 0x7d;
 let kWasmF64 = 0x7c;
 let kWasmS128 = 0x7b;
-let kWasmAnyRef = 0x6f;
-let kWasmAnyFunc = 0x70;
+
+// These are defined as negative integers to distinguish them from positive type
+// indices.
+let kWasmNullFuncRef = -0x0d;
+let kWasmNullExternRef = -0x0e;
+let kWasmNullRef = -0x0f;
+let kWasmFuncRef = -0x10;
+let kWasmAnyFunc = kWasmFuncRef;  // Alias named as in the JS API spec
+let kWasmExternRef = -0x11;
+let kWasmAnyRef = -0x12;
+
+// Use the positive-byte versions inside function bodies.
+let kLeb128Mask = 0x7f;
+let kFuncRefCode = kWasmFuncRef & kLeb128Mask;
+let kAnyFuncCode = kFuncRefCode;  // Alias named as in the JS API spec
+let kExternRefCode = kWasmExternRef & kLeb128Mask;
+let kAnyRefCode = kWasmAnyRef & kLeb128Mask;
+let kNullExternRefCode = kWasmNullExternRef & kLeb128Mask;
+let kNullFuncRefCode = kWasmNullFuncRef & kLeb128Mask;
+let kNullRefCode = kWasmNullRef & kLeb128Mask;
+
+let kWasmRefNull = 0x63;
+let kWasmRef = 0x64;
+function wasmRefNullType(heap_type, is_shared = false) {
+  return {opcode: kWasmRefNull, heap_type: heap_type, is_shared: is_shared};
+}
+function wasmRefType(heap_type, is_shared = false) {
+  return {opcode: kWasmRef, heap_type: heap_type, is_shared: is_shared};
+}
 
 let kExternalFunction = 0;
 let kExternalTable = 1;
@@ -146,14 +173,14 @@ let kSig_v_f = makeSig([kWasmF32], []);
 let kSig_f_f = makeSig([kWasmF32], [kWasmF32]);
 let kSig_f_d = makeSig([kWasmF64], [kWasmF32]);
 let kSig_d_d = makeSig([kWasmF64], [kWasmF64]);
-let kSig_r_r = makeSig([kWasmAnyRef], [kWasmAnyRef]);
+let kSig_r_r = makeSig([kWasmExternRef], [kWasmExternRef]);
 let kSig_a_a = makeSig([kWasmAnyFunc], [kWasmAnyFunc]);
-let kSig_i_r = makeSig([kWasmAnyRef], [kWasmI32]);
-let kSig_v_r = makeSig([kWasmAnyRef], []);
+let kSig_i_r = makeSig([kWasmExternRef], [kWasmI32]);
+let kSig_v_r = makeSig([kWasmExternRef], []);
 let kSig_v_a = makeSig([kWasmAnyFunc], []);
-let kSig_v_rr = makeSig([kWasmAnyRef, kWasmAnyRef], []);
+let kSig_v_rr = makeSig([kWasmExternRef, kWasmExternRef], []);
 let kSig_v_aa = makeSig([kWasmAnyFunc, kWasmAnyFunc], []);
-let kSig_r_v = makeSig([], [kWasmAnyRef]);
+let kSig_r_v = makeSig([], [kWasmExternRef]);
 let kSig_a_v = makeSig([], [kWasmAnyFunc]);
 let kSig_a_i = makeSig([kWasmI32], [kWasmAnyFunc]);
 
@@ -1161,7 +1188,7 @@ class WasmModuleBuilder {
               local_decls.push({count: l.s128_count, type: kWasmS128});
             }
             if (l.anyref_count > 0) {
-              local_decls.push({count: l.anyref_count, type: kWasmAnyRef});
+              local_decls.push({count: l.anyref_count, type: kWasmExternRef});
             }
             if (l.anyfunc_count > 0) {
               local_decls.push({count: l.anyfunc_count, type: kWasmAnyFunc});

--- a/test/legacy/exceptions/js-api/basic.tentative.any.js
+++ b/test/legacy/exceptions/js-api/basic.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_throws_wasm(fn, message) {
@@ -11,8 +11,7 @@ function assert_throws_wasm(fn, message) {
 }
 
 promise_test(async () => {
-  const kWasmAnyRef = 0x6f;
-  const kSig_v_r = makeSig([kWasmAnyRef], []);
+  const kSig_v_r = makeSig([kWasmExternRef], []);
   const builder = new WasmModuleBuilder();
   const tagIndex = builder.addTag(kSig_v_r);
   builder.addFunction("throw_param", kSig_v_r)
@@ -48,7 +47,7 @@ promise_test(async () => {
   const tagIndex = builder.addTag(kSig_v_a);
   builder.addFunction("throw_null", kSig_v_v)
     .addBody([
-      kExprRefNull, kWasmAnyFunc,
+      kExprRefNull, kAnyFuncCode,
       kExprThrow, tagIndex,
     ])
     .exportFunc();
@@ -82,7 +81,7 @@ promise_test(async () => {
       kExprCatch, tagIndex,
         kExprReturn,
       kExprEnd,
-      kExprRefNull, kWasmAnyRef,
+      kExprRefNull, kExternRefCode,
     ])
     .exportFunc();
 
@@ -106,7 +105,7 @@ promise_test(async () => {
       kExprCatchAll,
         kExprRethrow, 0x00,
       kExprEnd,
-      kExprRefNull, kWasmAnyRef,
+      kExprRefNull, kExternRefCode,
     ])
     .exportFunc();
 

--- a/test/legacy/exceptions/js-api/identity.tentative.any.js
+++ b/test/legacy/exceptions/js-api/identity.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 


### PR DESCRIPTION
This reflects the WPT changes in
https://github.com/web-platform-tests/wpt/commit/5623804845b906f272c3f808e717c50f5cd8e14e https://github.com/web-platform-tests/wpt/commit/e0c0429460a5982c4e4889026dbfbcb60c3c9ef9 and https://github.com/web-platform-tests/wpt/pull/42764

`wasm-module-builder.js` was not fully synced with the WPT repo; the changes reflected were just enough to pass the tests.

This also changes `worker` from `dedicatedworker` in `legacy/exceptions/js-api/basic.tentative.any.js`, even though the matching WPT test has not been updated to use it, because all other tests seem to be using `dedicatedworker` now.