### PR TITLE
[js-api] Update wasm-module-builder.js for exnref

### DIFF
--- a/test/legacy/exceptions/js-api/basic.tentative.any.js
+++ b/test/legacy/exceptions/js-api/basic.tentative.any.js
@@ -76,7 +76,7 @@ promise_test(async () => {
   const tagIndex= builder.addTag(kSig_v_r);
   builder.addFunction("catch_exception", kSig_r_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, fnIndex,
       kExprCatch, tagIndex,
         kExprReturn,
@@ -100,7 +100,7 @@ promise_test(async () => {
   const fnIndex = builder.addImport("module", "fn", kSig_v_v);
   builder.addFunction("catch_and_rethrow", kSig_r_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, fnIndex,
       kExprCatchAll,
         kExprRethrow, 0x00,

--- a/test/legacy/exceptions/js-api/identity.tentative.any.js
+++ b/test/legacy/exceptions/js-api/identity.tentative.any.js
@@ -35,7 +35,7 @@ test(() => {
   builder
     .addFunction("catch_js_tag_rethrow", kSig_v_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, throwJSTagExnIndex,
       kExprCatch, jsTagIndex,
         kExprDrop,
@@ -49,7 +49,7 @@ test(() => {
   builder
     .addFunction("catch_wasm_tag_rethrow", kSig_v_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, throwWasmTagExnIndex,
       kExprCatch, wasmTagIndex,
         kExprDrop,
@@ -63,7 +63,7 @@ test(() => {
   builder
     .addFunction("catch_all_js_tag_rethrow", kSig_v_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, throwJSTagExnIndex,
       kExprCatchAll,
         kExprRethrow, 0x00,
@@ -76,7 +76,7 @@ test(() => {
   builder
     .addFunction("catch_all_wasm_tag_rethrow", kSig_v_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, throwWasmTagExnIndex,
       kExprCatchAll,
         kExprRethrow, 0x00,
@@ -103,7 +103,7 @@ test(() => {
   builder
     .addFunction("catch_js_tag_throw_payload", kSig_v_v)
     .addBody([
-      kExprTry, kWasmStmt,
+      kExprTry, kWasmVoid,
         kExprCallFunction, throwJSTagExnIndex,
       kExprCatch, jsTagIndex,
         kExprThrow, jsTagIndex,


### PR DESCRIPTION
This pulls in some exnref-related changes from
https://github.com/v8/v8/blob/main/test/mjsunit/wasm/wasm-module-builder.js but does not sync with it completely. That v8 version contains a lot of features from new proposals that are not really relevant to EH and exnref, so this pulls only the relevant EH parts in.

This also renames `kWasmStmt` to `kWasmVoid` as in the V8 version, because it looks more intuitive. Also renames `kTagAttribute` to `kExceptionAttribute`.