### PR TITLE
[js-api] Update basic and identity tests for exnref

### DIFF
--- a/test/js-api/exception/basic.tentative.any.js
+++ b/test/js-api/exception/basic.tentative.any.js
@@ -13,11 +13,11 @@ function assert_throws_wasm(fn, message) {
 promise_test(async () => {
   const kSig_v_r = makeSig([kWasmExternRef], []);
   const builder = new WasmModuleBuilder();
-  const tagIndex = builder.addTag(kSig_v_r);
+  const tagIndexExternref = builder.addTag(kSig_v_r);
   builder.addFunction("throw_param", kSig_v_r)
     .addBody([
       kExprLocalGet, 0,
-      kExprThrow, tagIndex,
+      kExprThrow, tagIndexExternref,
     ])
     .exportFunc();
   const buffer = builder.toBuffer();
@@ -44,11 +44,11 @@ promise_test(async () => {
 
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
-  const tagIndex = builder.addTag(kSig_v_a);
+  const tagIndexAnyref = builder.addTag(kSig_v_a);
   builder.addFunction("throw_null", kSig_v_v)
     .addBody([
       kExprRefNull, kAnyFuncCode,
-      kExprThrow, tagIndex,
+      kExprThrow, tagIndexAnyref,
     ])
     .exportFunc();
   const buffer = builder.toBuffer();
@@ -58,11 +58,11 @@ promise_test(async () => {
 
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
-  const tagIndex = builder.addTag(kSig_v_i);
+  const tagIndexI32 = builder.addTag(kSig_v_i);
   builder.addFunction("throw_int", kSig_v_v)
     .addBody([
       ...wasmI32Const(7),
-      kExprThrow, tagIndex,
+      kExprThrow, tagIndexI32,
     ])
     .exportFunc();
   const buffer = builder.toBuffer();
@@ -73,12 +73,18 @@ promise_test(async () => {
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
   const fnIndex = builder.addImport("module", "fn", kSig_v_v);
-  const tagIndex= builder.addTag(kSig_v_r);
+  const tagIndexExternref = builder.addTag(kSig_v_r);
+
   builder.addFunction("catch_exception", kSig_r_v)
     .addBody([
-      kExprTry, kWasmVoid,
-        kExprCallFunction, fnIndex,
-      kExprCatch, tagIndex,
+      kExprBlock, kWasmVoid,
+        kExprBlock, kExternRefCode,
+          kExprTryTable, kWasmVoid, 1,
+            kCatchNoRef, tagIndexExternref, 0,
+            kExprCallFunction, fnIndex,
+          kExprEnd,
+          kExprBr, 1,
+        kExprEnd,
         kExprReturn,
       kExprEnd,
       kExprRefNull, kExternRefCode,
@@ -100,10 +106,15 @@ promise_test(async () => {
   const fnIndex = builder.addImport("module", "fn", kSig_v_v);
   builder.addFunction("catch_and_rethrow", kSig_r_v)
     .addBody([
-      kExprTry, kWasmVoid,
-        kExprCallFunction, fnIndex,
-      kExprCatchAll,
-        kExprRethrow, 0x00,
+      kExprBlock, kWasmVoid,
+        kExprBlock, kExnRefCode,
+          kExprTryTable, kWasmVoid, 1,
+            kCatchAllRef, 0,
+            kExprCallFunction, fnIndex,
+          kExprEnd,
+          kExprBr, 1,
+        kExprEnd,
+        kExprThrowRef,
       kExprEnd,
       kExprRefNull, kExternRefCode,
     ])
@@ -118,3 +129,55 @@ promise_test(async () => {
   });
   assert_throws_exactly(error, () => instance.exports.catch_and_rethrow());
 }, "Imported JS function throws, Wasm catches and rethrows");
+
+promise_test(async () => {
+  const builder = new WasmModuleBuilder();
+  const fnIndex = builder.addImport("module", "fn", kSig_v_v);
+  const tagI32 = new WebAssembly.Tag({ parameters: ["i32"] });
+  const tagIndexI32 = builder.addImportedTag("module", "tagI32", kSig_v_i);
+  const exn = new WebAssembly.Exception(tagI32, [42]);
+  const kSig_ie_v = makeSig([], [kWasmI32, kExnRefCode]);
+  const sig_ie_v = builder.addType(kSig_ie_v);
+
+  builder.addFunction("all_catch_clauses", kSig_i_v)
+    .addBody([
+      kExprBlock, kWasmVoid,
+        kExprBlock, kExnRefCode,
+          kExprBlock, sig_ie_v,
+            kExprBlock, kWasmVoid,
+              kExprBlock, kWasmI32,
+                kExprTryTable, kWasmVoid, 4,
+                  kCatchNoRef, tagIndexI32, 0,
+                  kCatchAllNoRef, 1,
+                  kCatchRef, tagIndexI32, 2,
+                  kCatchAllRef, 3,
+                  kExprCallFunction, fnIndex,
+                kExprEnd,
+                kExprBr, 4,
+              kExprEnd,
+              kExprReturn,
+            kExprEnd,
+                kExprUnreachable,
+            kExprBr, 2,
+          kExprEnd,
+          kExprDrop,
+          kExprDrop,
+          kExprBr, 1,
+        kExprEnd,
+        kExprDrop,
+      kExprEnd,
+      kExprI32Const, 33,
+    ])
+    .exportFunc();
+
+  const buffer = builder.toBuffer();
+
+  const fn = () => {
+    throw exn;
+  };
+  const {instance} = await WebAssembly.instantiate(buffer, {
+    module: { fn, tagI32: tagI32 }
+  });
+  result = instance.exports.all_catch_clauses();
+  assert_equals(result, 42);
+}, "try-table uses all four kinds of catch clauses, one of which catches an exception");

--- a/test/js-api/exception/basic.tentative.any.js
+++ b/test/js-api/exception/basic.tentative.any.js
@@ -177,6 +177,6 @@ promise_test(async () => {
   const {instance} = await WebAssembly.instantiate(buffer, {
     module: { fn, tagI32: tagI32 }
   });
-  result = instance.exports.all_catch_clauses();
+  const result = instance.exports.all_catch_clauses();
   assert_equals(result, 42);
 }, "try-table uses all four kinds of catch clauses, one of which catches an exception");

--- a/test/js-api/exception/basic.tentative.any.js
+++ b/test/js-api/exception/basic.tentative.any.js
@@ -157,7 +157,6 @@ promise_test(async () => {
               kExprEnd,
               kExprReturn,
             kExprEnd,
-                kExprUnreachable,
             kExprBr, 2,
           kExprEnd,
           kExprDrop,
@@ -166,7 +165,7 @@ promise_test(async () => {
         kExprEnd,
         kExprDrop,
       kExprEnd,
-      kExprI32Const, 33,
+      kExprI32Const, 0,
     ])
     .exportFunc();
 

--- a/test/legacy/exceptions/js-api/basic.tentative.any.js
+++ b/test/legacy/exceptions/js-api/basic.tentative.any.js
@@ -73,7 +73,7 @@ promise_test(async () => {
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
   const fnIndex = builder.addImport("module", "fn", kSig_v_v);
-  const tagIndex= builder.addTag(kSig_v_r);
+  const tagIndex = builder.addTag(kSig_v_r);
   builder.addFunction("catch_exception", kSig_r_v)
     .addBody([
       kExprTry, kWasmVoid,


### PR DESCRIPTION
This updates `basic.tentative.any.js` and `identity.tentative.any.js` tests to use the new instructions (`try_table` and `throw_ref`). In addition to converting existing tests to use the new instruction while maintaining the semantics, I added a new test in
`basic.tentative.any.js` that makes use of all four `catch` clause variants to show all catch clauses works well in JS API tests.

These new tests reauire `--js-flags=--experimental-wasm-exnref` argument to chrome, which is not currently supported in WPT out of the box. I've instead confirmed these run with chrome web tests infrastructure (https://chromium.googlesource.com/chromium/src/+/HEAD/docs/testing/web_tests.md#Running-Web-Tests).