### PR TITLE
Rename section 4.7 from "Tags" to "Exceptions"

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1187,7 +1187,7 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
 
 </div>
 
-<h3 id="tags">Tags</h3>
+<h3 id="exceptions">Exceptions</h3>
 
 <h4 id="exceptions-types">Exception types</h4>
 


### PR DESCRIPTION
This section is about general exception-related topics, not just tags.