### PR TITLE
add a test case

### DIFF
--- a/test/core/try_table.wast
+++ b/test/core/try_table.wast
@@ -9,6 +9,7 @@
 
 (module
   (tag $imported-e0 (import "test" "e0"))
+  (tag $imported-e0-alias (import "test" "e0"))
   (func $imported-throw (import "test" "throw"))
   (tag $e0)
   (tag $e1)
@@ -211,6 +212,16 @@
     (i32.const 2)
   )
 
+  (func (export "catch-imported-alias") (result i32)
+    (block $h
+      (try_table (result i32) (catch $imported-e0 $h)
+        (throw $imported-e0-alias (i32.const 1))
+      )
+      (return)
+    )
+    (i32.const 2)
+  )
+
   (func (export "catchless-try") (param i32) (result i32)
     (block $h
       (try_table (result i32) (catch $e0 $h)
@@ -291,6 +302,7 @@
 (assert_return (invoke "catch-param-i32" (i32.const 5)) (i32.const 5))
 
 (assert_return (invoke "catch-imported") (i32.const 2))
+(assert_return (invoke "catch-imported-alias") (i32.const 2))
 
 (assert_return (invoke "catchless-try" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "catchless-try" (i32.const 1)) (i32.const 1))


### PR DESCRIPTION
some runtimes implement tag matching as the equality of tag indexes. (cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/3109) i believe it's a wrong interpreteation of the spec. this test case ensures a failure on such implementations.