### PR TITLE
Add link to legacy proposal in explainer

### DIFF
--- a/proposals/exception-handling/Exceptions.md
+++ b/proposals/exception-handling/Exceptions.md
@@ -3,6 +3,10 @@
 This explainer reflects the up-to-date version of the exception handling
 proposal agreed on [Oct 2023 CG
 meeting](https://github.com/WebAssembly/meetings/blob/main/main/2023/CG-10.md#exception-handling-vote-on-proposal-to-re-introduce-exnref).
+See the [legacy
+proposal](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/legacy/Exceptions.md)
+for the previous version of the proposal that is still supported in several
+browsers.
 
 ---
 


### PR DESCRIPTION
I found that the legacy and pre-legacy proposals have links to their immediate predecessor and successor but the current proposal does not have a link to its (immediate) predecessor. Given that the current proposal is not yet supported without flags in many browsers, it would help people who want to look at the legacy proposal but don't know there is a separate `legacy/` directory.